### PR TITLE
add Romo.Spinner DOM component

### DIFF
--- a/lib/api/dom_attributes.js
+++ b/lib/api/dom_attributes.js
@@ -67,6 +67,11 @@ Romo.rmStyle =
 
 Romo.css =
   function(element, styleName) {
+    const dom = Romo.dom(element)
+    if (!dom.firstElement) {
+      throw new Error('Romo.css: no element given.')
+    }
+
     return (
       window
         .getComputedStyle(Romo.dom(element).firstElement, null)

--- a/lib/api/dom_attributes.js
+++ b/lib/api/dom_attributes.js
@@ -49,6 +49,14 @@ Romo.setStyle =
     return elements
   }
 
+Romo.batchSetStyle =
+  function(elements, styles) {
+    for (var styleName in styles) {
+      Romo.setStyle(Romo.dom(elements), styleName, styles[styleName])
+    }
+    return elements
+  }
+
 Romo.rmStyle =
   function(elements, styleName) {
     Romo.dom(elements).forEach(function(element) {

--- a/lib/components.css
+++ b/lib/components.css
@@ -1,0 +1,1 @@
+@import './components/spinner.css';

--- a/lib/components.js
+++ b/lib/components.js
@@ -1,0 +1,1 @@
+import './components/spinner.js'

--- a/lib/components/dom_component.js
+++ b/lib/components/dom_component.js
@@ -1,0 +1,10 @@
+// Romo.DOMComponent is a common base class for Romo JS components that bind to
+// a DOM element, are configured by DOM data attributes, and interact using DOM
+// events.
+Romo.define('Romo.DOMComponent', function() {
+  return class {
+    constructor(element) {
+      this.dom = Romo.dom(element)
+    }
+  }
+})

--- a/lib/components/spinner.css
+++ b/lib/components/spinner.css
@@ -1,0 +1,2 @@
+/* https://cdn.skypack.dev/spin.js@v4.1.0/spin.css */
+@import 'https://cdn.skypack.dev/-/spin.js@v4.1.0-xmnFx39PWHmGEVZL6LAZ/dist=es2020,mode=raw/spin.css';

--- a/lib/components/spinner.js
+++ b/lib/components/spinner.js
@@ -1,0 +1,146 @@
+import './dom_component.js'
+// https://cdn.skypack.dev/spin.js@v4.1.0
+import { Spinner } from 'https://cdn.skypack.dev/pin/spin.js@v4.1.0-xmnFx39PWHmGEVZL6LAZ/min/spinjs.js'
+
+// Romo.Spinner extends a DOM element so that it can display a spinner when
+// directed. It uses DOM attributes to configure the spinner and uses DOM
+// events to interact with the spinner.
+//
+// Romo.Spinner composes https://spin.js.org/spin.js.
+Romo.define('Romo.Spinner', function() {
+  return class extends Romo.DOMComponent {
+    constructor(dom) {
+      super(dom)
+
+      this.dom.on('Romo.Spinner:triggerStart', Romo.bind(function(e, basisSizePxPx) {
+        this.doStart(basisSizePxPx)
+      }, this))
+      this.dom.on('Romo.Spinner:triggerStop', Romo.bind(function(e) {
+        this.doStop()
+      }, this))
+
+      // TODO: do this with only a single window pageshow event handler to
+      // scale better.
+      if (this.stopOnPageshow !== false) {
+        Romo.dom(window).on('pageshow', Romo.bind(function(e) {
+          this.dom.trigger('Romo.Spinner:triggerStop')
+        }, this))
+      }
+    }
+
+    get sizePx() {
+      return this.dom.data('romo-spinner-size-px')
+    }
+
+    get containerSelector() {
+      return this.dom.data('romo-spinner-container-selector')
+    }
+
+    get stopOnPageshow() {
+      return this.dom.data('romo-spinner-stop-on-pageshow')
+    }
+
+    get isDisabled() {
+      return this.dom.data('romo-spinner-disabled')
+    }
+
+    get containerDOM() {
+      return Romo.memoize(this, 'containerDOM', function() {
+        if (this.containerSelector) {
+          return this.dom.find(this.containerSelector)
+        } else {
+          return this.dom
+        }
+      })
+    }
+
+    doStart(customBasisSizePx) {
+      if (this.spinner || this.isDisabled) {
+        return
+      }
+
+      var basisSizePx = (
+        customBasisSizePx ||
+        this.sizePx ||
+        Math.min(Romo.width(this.containerDOM), Romo.height(this.containerDOM))
+      )
+
+      var spinnerOptions = {
+        /* eslint-disable key-spacing, no-multi-spaces */
+        animation: 'spinner-line-fade-quick',       // The CSS animation name for the lines
+        lines:     11,                              // The number of lines to draw
+        width:     2.0,                             // The line thickness
+        length:    parseInt(basisSizePx, 10) / 5.0, // The length of each line
+        radius:    parseInt(basisSizePx, 10) / 6.0, // The radius of the inner circle
+        corners:   1,                               // Corner roundness (0..1)
+        rotate:    0,                               // The rotation offset
+        direction: 1,                               // 1: clockwise, -1: counterclockwise
+        color:     this.containerDOM.css('color'),  // #rgb or #rrggbb or array of colors
+        speed:     1,                               // Rounds per second
+        trail:     60,                              // Afterglow percentage
+        shadow:    false,                           // Whether to render a shadow
+        hwaccel:   false,                           // Whether to use hardware acceleration
+        className: '',                              // The CSS class to assign to the spinner
+        zIndex:    1000,                            // The z-index (defaults to 2000000000)
+        top:       '50%',                           // Top position relative to parent
+        left:      '50%',                           // Left position relative to parent
+        /* eslint-enable key-spacing, no-multi-spaces */
+      }
+      this.spinner = new Spinner(spinnerOptions)
+
+      this.containerHTML = this.containerDOM.innerHTML
+      this.containerStyle = this.containerDOM.attr('style')
+
+      Romo.pushFn(Romo.bind(function() {
+        this.containerDOM
+          .batchSetStyle({
+            position:        'relative',
+            width:           Romo.width(this.containerDOM) + 'px',
+            height:          Romo.height(this.containerDOM) + 'px',
+            color:           this.containerDOM.css('color'),
+            backgroundColor: this.containerDOM.css('background-color'),
+            borderColor:     this.containerDOM.css('border-color'),
+          })
+          .clearHTML()
+
+        if (this.spinner) {
+          this.spinner.spin(this.containerDOM.firstElement)
+        }
+
+        this.dom.trigger('Romo.Spinner:started', [this])
+      }, this))
+    }
+
+    doStop() {
+      Romo.pushFn(Romo.bind(function() {
+        if (this.spinner === undefined) {
+          return
+        }
+
+        this.spinner.stop()
+        this.spinner = undefined
+
+        if (this.containerHTML) {
+          this.containerDOM.innerHTML = this.containerHTML
+        }
+
+        this.containerDOM.batchSetStyle({
+          position:        '',
+          width:           '',
+          height:          '',
+          color:           '',
+          backgroundColor: '',
+          borderColor:     '',
+        })
+
+        if (this.containerStyle) {
+          this.containerDOM.setAttr('style', this.containerStyle)
+        }
+
+        this.dom.trigger('Romo.Spinner:stopped', [this])
+      }, this))
+    }
+  }
+})
+
+Romo.addAutoInitSelector('[data-romo-spinner]', Romo.Spinner)

--- a/lib/env.js
+++ b/lib/env.js
@@ -41,7 +41,7 @@ class RomoEnv {
 
   setup() {
     if (this._hasBeenSetup !== true) {
-      // TODO: add setup logic here.
+      this.applyAutoInitTo(Romo.f('body'))
 
       this._hasBeenSetup = true
     }

--- a/lib/romo.css
+++ b/lib/romo.css
@@ -1,0 +1,5 @@
+@import './components.css';
+
+body, body * {
+  box-sizing: border-box;
+}

--- a/lib/romo.js
+++ b/lib/romo.js
@@ -1,5 +1,6 @@
 import './env.js'
 import './api.js'
 import './utilities.js'
+import './components.js'
 
 Romo.setup()

--- a/lib/utilities/dom.js
+++ b/lib/utilities/dom.js
@@ -100,6 +100,10 @@ Romo.define('Romo.DOM', function() {
       return Romo.dom(Romo.setStyle(this, styleName, styleValue))
     }
 
+    batchSetStyle(styles) {
+      return Romo.dom(Romo.batchSetStyle(this, styles))
+    }
+
     rmStyle(styleName) {
       return Romo.dom(Romo.rmStyle(this, styleName))
     }

--- a/lib/utilities/dom.js
+++ b/lib/utilities/dom.js
@@ -182,6 +182,10 @@ Romo.define('Romo.DOM', function() {
       return Romo.innerHTML(this)
     }
 
+    find(selector) {
+      return Romo.find(this, selector)
+    }
+
     is(selector) {
       return Romo.is(this, selector)
     }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "scripts": {
     "lint": "./bin/lint",
+    "refresh": "./bin/cp-source-for-tests",
     "test": "./bin/test"
   },
   "repository": {

--- a/test/dom_components/spinner_tests.html
+++ b/test/dom_components/spinner_tests.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="/support/romo-js/romo.css"/>
+  <style>
+  </style>
+</head>
+<body>
+  <h1>Romo.Spinner system tests</h1>
+  <div style="display: inline-block; border: 1px solid black; height: 10px"
+       data-toggle-spinner
+       data-romo-spinner>Toggle Spinner</div><br/><br/>
+  <div style="display: inline-block; border: 1px solid black; height: 20px"
+       data-toggle-spinner
+       data-romo-spinner>Toggle Spinner</div><br/><br/>
+  <div style="display: inline-block; border: 1px solid black; height: 30px"
+       data-toggle-spinner
+       data-romo-spinner>Toggle Spinner</div><br/><br/>
+  <div style="display: inline-block; border: 1px solid black; height: 40px"
+       data-toggle-spinner
+       data-romo-spinner>Toggle Spinner</div><br/><br/>
+  <div style="display: inline-block; border: 1px solid black; height: 50px"
+       data-toggle-spinner
+       data-romo-spinner>Toggle Spinner</div><br/><br/>
+  <button style="height: 10px"
+          data-toggle-spinner
+          data-romo-spinner>Toggle Spinner</button><br/><br/>
+  <button style="height: 20px"
+          data-toggle-spinner
+          data-romo-spinner>Toggle Spinner</button><br/><br/>
+  <button style="height: 30px"
+          data-toggle-spinner
+          data-romo-spinner>Toggle Spinner</button><br/><br/>
+  <button style="height: 40px"
+          data-toggle-spinner
+          data-romo-spinner>Toggle Spinner</button><br/><br/>
+  <button style="height: 50px"
+          data-toggle-spinner
+          data-romo-spinner>Toggle Spinner</button><br/><br/>
+</body>
+<script type="module" src="/support/romo-js/romo.js"></script>
+<script type="module" src="/support/tests.js"></script>
+<script type="module">
+  Romo.onReady(function() {
+    Romo
+      .f('[data-romo-spinner]')
+      .on('Romo.Spinner:started', function(e, romoSpinner) {
+        romoSpinner.dom.setData('spinning', true)
+      })
+      .on('Romo.Spinner:stopped', function(e, romoSpinner) {
+        romoSpinner.dom.setData('spinning', false)
+      })
+      .on('click', function(e) {
+        const targetDOM = Romo.dom(e.target)
+        if (targetDOM.data('spinning')) {
+          targetDOM.trigger('Romo.Spinner:triggerStop')
+        } else {
+          targetDOM.trigger('Romo.Spinner:triggerStart')
+        }
+      })
+  })
+</script>

--- a/test/support/lighttpd.conf.example
+++ b/test/support/lighttpd.conf.example
@@ -5,5 +5,6 @@ server.pid-file = "/path/to/local/romo-js/test/support/lighttpd.pid"
 
 mimetype.assign = (
   ".html" => "text/html",
-  ".js"   => "text/javascript"
+  ".js"   => "text/javascript",
+  ".css"  => "text/css"
 )

--- a/test/support/tests.js
+++ b/test/support/tests.js
@@ -1,0 +1,78 @@
+Romo.define('Tests', function() {
+  return class {
+    constructor(dom) {
+      this.dom = dom
+    }
+
+    group(name, fn) {
+      this.dom.appendHTML(`<h3>${name}</h3>`)
+      fn()
+    }
+
+    test(description, fn) {
+      const testDOM =
+        this.dom.appendHTML(`<div class="test">${description}</description>`)
+
+      // eslint-disable-next-line no-undef
+      new Tests.Test(testDOM).run(fn)
+    }
+  }
+})
+
+Romo.define('Tests.Test', function() {
+  return class {
+    constructor(dom) {
+      this.dom = dom
+      this.success = true
+    }
+
+    run(fn) {
+      try {
+        fn(this)
+      } catch (error) {
+        this.unstubConsoleError()
+        console.error(error)
+        this.fail()
+      }
+      return this
+    }
+
+    assert(assertion) {
+      if (assertion) {
+        this.pass()
+      } else {
+        throw new Error('test assertion failed.')
+      }
+    }
+
+    pass() {
+      this.dom.addClass('pass').rmClass('fail')
+    }
+
+    fail(message) {
+      if (message) {
+        this.unstubConsoleError()
+        console.error(message)
+      }
+      this.dom.addClass('fail').rmClass('pass')
+    }
+
+    stubConsoleError() {
+      console.originalErrorFn = console.error.bind(console)
+      console.errorMessages = []
+      console.error =
+        function() {
+          console.errorMessages.push(Array.from(arguments))
+          console.log.apply(console, arguments)
+        }
+    }
+
+    unstubConsoleError() {
+      if (console.originalErrorFn) {
+        console.error = console.originalErrorFn.bind(console)
+        console.errorMessages = undefined
+        console.originalErrorFn = undefined
+      }
+    }
+  }
+})

--- a/test/system_tests.html
+++ b/test/system_tests.html
@@ -1282,6 +1282,18 @@
         test.assert(flashAlert.message === 'message 1')
       })
     })
+
+    tests.group('<code>Romo.DOMComponent</code>', function() {
+      tests.test('<code>Romo.DOMComponent</code>', function(test) {
+        var romoDOM
+
+        romoDOM = new Romo.DOMComponent(Romo.f('body'))
+        test.assert(romoDOM.dom.isRomoDOM === true)
+
+        romoDOM = new Romo.DOMComponent(Romo.f('body').firstElement)
+        test.assert(romoDOM.dom.isRomoDOM === true)
+      })
+    })
   })
 </script>
 </html>

--- a/test/system_tests.html
+++ b/test/system_tests.html
@@ -544,6 +544,15 @@
     })
 
     tests.group('API: DOM Query', function() {
+      tests.test('<code>find</code>', function(test) {
+        const dom = Romo.f('[data-test-support]')
+        const domA = Romo.f('[data-support-div-a]')
+        const foundDOMA = dom.find('[data-support-div-a]')
+
+        test.assert(foundDOMA.length === 1)
+        test.assert(foundDOMA.firstElement === domA.firstElement)
+      })
+
       tests.test('<code>innerText</code>', function(test) {
         const supportDOM = Romo.f('[data-test-support]')
         const subjectDOM = supportDOM.appendHTML('<div class="subject"></div>')

--- a/test/system_tests.html
+++ b/test/system_tests.html
@@ -22,86 +22,8 @@
   </div>
 </body>
 <script type="module" src="/support/romo-js/romo.js"></script>
+<script type="module" src="/support/tests.js"></script>
 <script type="module">
-  Romo.define('Tests', function() {
-    return class {
-      constructor(dom) {
-        this.dom = dom
-      }
-
-      group(name, fn) {
-        this.dom.appendHTML(`<h3>${name}</h3>`)
-        fn()
-      }
-
-      test(description, fn) {
-        const testDOM =
-          this.dom.appendHTML(`<div class="test">${description}</description>`)
-
-        // eslint-disable-next-line no-undef
-        new Tests.Test(testDOM).run(fn)
-      }
-    }
-  })
-
-  Romo.define('Tests.Test', function() {
-    return class {
-      constructor(dom) {
-        this.dom = dom
-        this.success = true
-      }
-
-      run(fn) {
-        try {
-          fn(this)
-        } catch (error) {
-          this.unstubConsoleError()
-          console.error(error)
-          this.fail()
-        }
-        return this
-      }
-
-      assert(assertion) {
-        if (assertion) {
-          this.pass()
-        } else {
-          throw new Error('test assertion failed.')
-        }
-      }
-
-      pass() {
-        this.dom.addClass('pass').rmClass('fail')
-      }
-
-      fail(message) {
-        if (message) {
-          this.unstubConsoleError()
-          console.error(message)
-        }
-        this.dom.addClass('fail').rmClass('pass')
-      }
-
-      stubConsoleError() {
-        console.originalErrorFn = console.error.bind(console)
-        console.errorMessages = []
-        console.error =
-          function() {
-            console.errorMessages.push(Array.from(arguments))
-            console.log.apply(console, arguments)
-          }
-      }
-
-      unstubConsoleError() {
-        if (console.originalErrorFn) {
-          console.error = console.originalErrorFn.bind(console)
-          console.errorMessages = undefined
-          console.originalErrorFn = undefined
-        }
-      }
-    }
-  })
-
   Romo.onReady(function() {
     const tests = new Tests(Romo.f('[data-test-output]'))
 

--- a/test/system_tests.html
+++ b/test/system_tests.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="en">
 <head>
+  <link rel="stylesheet" type="text/css" href="/support/romo-js/romo.css"/>
   <style>
     .test:before {
       display: inline-block;
@@ -15,6 +16,12 @@
 </head>
 <body>
   <h1>Romo JS system tests</h1>
+  <div data-test-component-pages>
+    <h3>DOM Components</h3>
+    <ul>
+      <li><a href="./dom_components/spinner_tests.html">Romo.Spinner</a></li>
+    </ul>
+  </div>
   <div data-test-output></div>
   <div data-test-support>
     <div data-support-div-a style="display: none">Div A</div>

--- a/test/system_tests.html
+++ b/test/system_tests.html
@@ -358,6 +358,24 @@
         test.assert(rmStyleDOM === dom)
       })
 
+      tests.test('<code>batchSetStyle</code>', function(test) {
+        const dom = Romo.f('[data-support-div-a]')
+
+        const batchSetStyleDOM =
+          dom.batchSetStyle({
+            'color':      'red',
+            'background': 'green'
+          })
+        test.assert(dom.style('color') === 'red')
+        test.assert(dom.style('background') === 'green')
+        test.assert(batchSetStyleDOM === dom)
+
+        dom.batchSetStyle({
+          'color':      '',
+          'background': ''
+        })
+      })
+
       tests.test('<code>css</code>', function(test) {
         const dom = Romo.f('[data-support-div-a]')
         const originalCSSColor = dom.css('color')


### PR DESCRIPTION
This is a component that binds to a given DOM and layers in
Spinner behaviors. You interact with the component using DOM events
and configure with DOM data attributes.

### add Romo.DOMComponent bae class

This is a common base class all DOMComponents will extend. This is
prep for adding a Romo.Spinner DOM Component.

### break out test/support/tests.js into a separate script

This allows reusing this logic in multiple test pages. This is
prep for adding a separate test page for the coming Romo.Spinner
DOM Component.

### add Romo.batchSetStyle

This takes an Object of key/value pairs and calls `setStyle` for
each. This is a convience macros for setting styles and will be
used by the coming SC.Spinner component.

### add Romo.dom(...).find method

I originally added the main Romo.find method but forgot to add the
proxy method from the DOM object. This adds it in. I noticed this
while implementing the coming Romo.Spinner component.

![image0emui](https://user-images.githubusercontent.com/82110/102651526-4e22b600-4132-11eb-858d-5e16f64c9850.jpg)
