### PR TITLE
add Romo.ChildElementSet and API

### DIFF
--- a/lib/env.js
+++ b/lib/env.js
@@ -33,6 +33,12 @@ class RomoEnv {
     })
   }
 
+  get childElementSet() {
+    return Romo.memoize(this, 'childElementSet', function() {
+      return new Romo.ChildElementSet()
+    })
+  }
+
   get autoInit() {
     return Romo.memoize(this, 'autoInit', function() {
       return new Romo.AutoInit()
@@ -41,6 +47,7 @@ class RomoEnv {
 
   setup() {
     if (this._hasBeenSetup !== true) {
+      Romo.childElementSet = this.childElementSet
       this.applyAutoInitTo(Romo.f('body'))
 
       this._hasBeenSetup = true

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -1,4 +1,5 @@
 import './utilities/auto_init.js'
+import './utilities/child_element_set.js'
 import './utilities/dom.js'
 import './utilities/event_listeners.js'
 import './utilities/flash_alert.js'

--- a/lib/utilities/child_element_set.js
+++ b/lib/utilities/child_element_set.js
@@ -1,0 +1,124 @@
+// Romo.ChildElementSet tracks and observes "child" elements by their assigned
+// "parent" element. You can declare a set of child elements belongs to a parent
+// element. This sets up a MutationObserver that ensures that if a parent
+// element is removed from the DOM, all of its declared child elements are also
+// removed from the DOM.
+//
+// This is the default behavior for traditional DOM elements (the nested "child"
+// elements are removed from the DOM when their parent element is). However this
+// utility should be used when you have non-traditional parent/child elements
+// (where the child elements are dependent on other elements that aren't in
+// their element tree.
+Romo.define('Romo.ChildElementSet', function() {
+  return class {
+    constructor() {
+      this.nextElementID = 1
+      this.elements = {}
+
+      this.parentRemovedObserver.observe(
+        Romo.f('body').firstElement,
+        {
+          childList: true,
+          subtree:   true,
+        }
+      )
+    }
+
+    get elementIDDataName() {
+      return 'romo-child-elements-set-parent-element-id'
+    }
+
+    get elementIDAttributeName() {
+      return `data-${this.elementIDDataName}`
+    }
+
+    get parentRemovedObserver() {
+      return Romo.memoize(this, 'parentRemovedObserver', function() {
+        return new MutationObserver(
+          Romo.bind(function(mutationRecords) {
+            mutationRecords.forEach(Romo.bind(function(mutationRecord) {
+              if (
+                mutationRecord.type === 'childList' &&
+                mutationRecord.removedNodes.length > 0
+              ) {
+                Romo.array(mutationRecord.removedNodes).forEach(
+                  Romo.bind(function(removedNode) {
+                    this.remove(removedNode)
+                  }, this)
+                )
+              }
+            }, this))
+          }, this)
+        )
+      })
+    }
+
+    add(parent, children) {
+      // Delay adding because the parent element may be manipulated in the DOM
+      // resulting in the parent element being removed and then re-added to the
+      //  DOM. If the child elements are associated immediately, any removal
+      // due to DOM manipulation would incorrectly remove the child elements.
+      Romo.pushFn(Romo.bind(function() {
+        const parentDOM = Romo.dom(parent)
+        parentDOM.setData(
+          this.elementIDDataName,
+          this._push(parentDOM.data(this.elementIDDataName), Romo.dom(children))
+        )
+      }, this))
+    }
+
+    remove(element) {
+      if (element.nodeType !== Node.ELEMENT_NODE) {
+        return
+      }
+      const dom = Romo.dom(element)
+      if (dom.data('romo-child-element-set-disabled') !== true) {
+        if (dom.data(this.elementIDDataName)) {
+          // This element is a parent element itself, remove its children.
+          this._removeChildElems(dom)
+        }
+
+        Romo
+          .array(dom.find(`[${this.elementIDAttributeName}]`))
+          .forEach(
+            Romo.bind(function(nestedParentDOM) {
+              this._removeChildElems(nestedParentDOM)
+            }, this)
+          )
+      }
+    }
+
+    // private
+
+    _removeChildElems(dom) {
+      Romo
+        .array(this._pop(dom.data(this.elementIDDataName)))
+        .forEach(
+          function(childElement) {
+            childElement.remove()
+            Romo.trigger(childElement, 'Romo.ChildElementSet:removed', [this])
+          }
+        )
+    }
+
+    _push(parentID, childrenDOM) {
+      if (parentID === undefined) {
+        parentID = String(this.nextElementID++)
+      }
+
+      if (this.elements[parentID] === undefined) {
+        this.elements[parentID] = Romo.dom()
+      }
+
+      this.elements[parentID] = this.elements[parentID].concat(childrenDOM)
+
+      return parentID
+    }
+
+    _pop(id) {
+      const itemsDOM = this.elements[id]
+      delete this.elements[id]
+      return itemsDOM || []
+    }
+  }
+})

--- a/test/system_tests.html
+++ b/test/system_tests.html
@@ -1292,6 +1292,50 @@
       })
     })
 
+    tests.group('<code>Romo.ChildElementSet</code>', function() {
+      tests.test('<code>Romo.childElementsSet</code>', function(test) {
+        const supportDOM = Romo.f('[data-test-support]')
+        supportDOM.appendHTML(`
+<div class="root"></div>
+<div class="root-level1-A"></div>
+<div class="root-level1A-level2-A"></div>
+<div class="root-level1-B"></div>
+<div class="root-level1B-level2-A"></div>
+`)
+
+        Romo.childElementSet.add(
+          Romo.f('.root'),
+          [Romo.f('.root-level1-A, .root-level1-B')]
+        )
+        Romo.childElementSet.add(
+          Romo.f('.root-level1-A'),
+          Romo.f('.root-level1A-level2-A')
+        )
+        Romo.childElementSet.add(
+          Romo.f('.root-level1-B'),
+          Romo.f('.root-level1B-level2-A')
+        )
+
+        Romo.pushFn(function() {
+          test.assert(Romo.f('.root-level1-A').length === 1)
+          test.assert(Romo.f('.root-level1A-level2-A').length === 1)
+          test.assert(Romo.f('.root-level1B-level2-A').length === 1)
+
+          Romo.f('.root-level1-B').remove()
+          Romo.pushFn(function() {
+            test.assert(Romo.f('.root-level1B-level2-A').length === 0)
+          })
+
+          Romo.f('.root').remove()
+          Romo.pushFn(function() {
+            test.assert(Romo.f('.root-level1-A').length === 0)
+            test.assert(Romo.f('.root-level1A-level2-A').length === 0)
+            test.assert(Romo.f('.root-level1B-level2-A').length === 0)
+          })
+        })
+      })
+    })
+
     tests.group('<code>Romo.DOMComponent</code>', function() {
       tests.test('<code>Romo.DOMComponent</code>', function(test) {
         var romoDOM


### PR DESCRIPTION
This API allows manually registering "child" elements that are not
actually nested under their parent element. It sets up a
MutationObserver and anytime a element is removed, if it has
child elements registered, they too will be removed.

![image4vadc](https://user-images.githubusercontent.com/82110/102724938-b27f7a00-42d8-11eb-93c9-a719ab8d5806.jpg)
