### PR TITLE
rework XHR handling in prep for Romo.Form component that submits using XHR

### DIFF
--- a/lib/api/page.js
+++ b/lib/api/page.js
@@ -38,19 +38,11 @@ Romo.alertAndReloadPage =
 
 // Override as desired.
 Romo.showFlashAlerts =
-  function(flashAlertObjects) {
+  function(romoFlashAlerts) {
     Romo.alert(
       Romo
-        .array(flashAlertObjects)
-        .map(function(flashAlertObject) {
-          return new Romo.FlashAlert(flashAlertObject)
-        })
-        .filter(function(flashAlert) {
-          return flashAlert.isMessagePresent
-        })
-        .map(function(flashAlert) {
-          return flashAlert.toString()
-        })
+        .array(romoFlashAlerts)
+        .map(function(romoFlashAlert) { return romoFlashAlert.toString() })
         .join('\n')
     )
   }

--- a/lib/api/page.js
+++ b/lib/api/page.js
@@ -8,17 +8,9 @@ Romo.redirectPage =
     window.location = redirectUrl
   }
 
-// Override as desired.
 Romo.alert =
-  function(alertMessage, { debugMessages, callbackFn } = {}) {
-    var message = alertMessage
-    var debugs = Romo.array(debugMessages)
-
-    if (debugMessages && debugs.length !== 0) {
-      message += `:\n${debugs.join('\n')}`
-    }
-
-    console.error(message)
+  function(alertMessage, { debugMessage, callbackFn } = {}) {
+    Romo.showAlert(alertMessage, debugMessage)
 
     if (callbackFn) {
       callbackFn()
@@ -34,6 +26,19 @@ Romo.alertAndReloadPage =
         callbackFn:    function() { Romo.reloadPage() },
       },
     )
+  }
+
+// Override as desired.
+Romo.showAlert =
+  function(alertMessage, debugMessage) {
+    if (alertMessage.length !== 0) {
+      var message = alertMessage
+
+      if (debugMessage) {
+        message += `:\n${debugMessage}`
+      }
+      console.error(message)
+    }
   }
 
 // Override as desired.

--- a/lib/api/xhr.js
+++ b/lib/api/xhr.js
@@ -7,3 +7,9 @@ Romo.urlSearch =
   function(...args) {
     return new Romo.URLSearchParams(...args).toString()
   }
+
+// Override as desired.
+Romo.xhrErrorAlertMessage =
+  function() {
+    return 'An error has occurred.'
+  }

--- a/lib/components/xhr.js
+++ b/lib/components/xhr.js
@@ -86,13 +86,13 @@ Romo.define('Romo.XHR', function() {
     }
 
     doBindCallOn(callOn) {
-      this.dom.on((callOn || this.callOn), Romo.bind(this._onCall, this))
+      this.dom.on((callOn || this.callOn), Romo.bind(this._onCallOn, this))
 
       return this
     }
 
     doUnbindCallOn(callOn) {
-      this.dom.off((callOn || this.callOn), Romo.bind(this._onCall, this))
+      this.dom.off((callOn || this.callOn), Romo.bind(this._onCallOn, this))
 
       return this
     }
@@ -112,12 +112,12 @@ Romo.define('Romo.XHR', function() {
       this.currentXHR = this._nullXHR
       this.errors = []
 
-      this.doUnbindCallOn()
-      this.doBindCallOn()
-
       if (this.disableWithSpinner) {
         this.romoSpinner = new Romo.Spinner(this.dom)
       }
+
+      this.doUnbindCallOn()
+      this.doBindCallOn()
 
       this.dom.on('Romo.XHR:triggerCall', Romo.bind(this._onTriggerCall, this))
       this.dom.on('Romo.XHR:triggerAbort', Romo.bind(this._onTriggerAbort, this))
@@ -247,12 +247,12 @@ Romo.define('Romo.XHR', function() {
       this.dom.trigger('Romo.XHR:callQueueEnd', [this])
     }
 
-    _onCall(e) {
+    _onCallOn(e) {
       e.preventDefault()
       e.stopPropagation()
 
       if (this.dom.hasClass('disabled') === false) {
-        // Make the call late-bound to let all callOn event handling finish
+        // Make the call late-bound to let all callOn event type handling finish
         // before making the call.
         Romo.pushFn(Romo.bind(this.doCall, this))
       }

--- a/lib/components/xhr.js
+++ b/lib/components/xhr.js
@@ -110,7 +110,6 @@ Romo.define('Romo.XHR', function() {
       this.callStarted = false
       this.callRunning = false
       this.currentXHR = this._nullXHR
-      this.flashAlerts = []
       this.errors = []
 
       this.doUnbindCallOn()
@@ -185,20 +184,10 @@ Romo.define('Romo.XHR', function() {
     }
 
     _onCallSuccess(responseData, status, xhr) {
-      const responseJSON = xhr.responseJSON
-      if (responseJSON && responseJSON.flashAlerts) {
-        this.flashAlerts = this.flashAlerts.concat(responseJSON.flashAlerts)
-      }
-
       this.dom.trigger('Romo.XHR:callSuccess', [this, responseData, xhr])
     }
 
     _onCallError(responseData, status, xhr) {
-      const responseJSON = xhr.responseJSON
-      if (responseJSON && responseJSON.flashAlerts) {
-        this.flashAlerts = this.flashAlerts.concat(responseJSON.flashAlerts)
-      }
-
       this.errors.push(`[${status}] ${xhr.statusText}: ${responseData}`)
       this.dom.trigger('Romo.XHR:callError', [this, responseData, xhr])
     }
@@ -229,11 +218,6 @@ Romo.define('Romo.XHR', function() {
 
     _completeCallQueue() {
       if (this.callStarted) {
-        if (this.flashAlerts.length !== 0) {
-          Romo.showFlashAlerts(this.flashAlerts)
-          this.flashAlerts = []
-        }
-
         if (this.errors.length !== 0) {
           this.dom.trigger('Romo.XHR:callQueueError', [this, this.errors])
 

--- a/lib/components/xhr.js
+++ b/lib/components/xhr.js
@@ -164,6 +164,7 @@ Romo.define('Romo.XHR', function() {
           method:       this.callMethod,
           data:         data,
           responseType: this.callResponseType,
+          reloadPageOn: this.reloadPageOn,
           onCallStart:  Romo.bind(this._onCallStart, this),
           onProgress:   Romo.bind(this._onCallProgress, this),
           onSuccess:    Romo.bind(this._onCallSuccess, this),
@@ -221,25 +222,9 @@ Romo.define('Romo.XHR', function() {
         if (this.errors.length !== 0) {
           this.dom.trigger('Romo.XHR:callQueueError', [this, this.errors])
 
-          if (this.reloadPageOn === 'complete' || this.reloadPageOn === 'error') {
-            Romo.alertAndReloadPage(
-              this.class.errorAlertMessage,
-              { debugMessages: this.errors },
-            )
-          } else {
-            Romo.alert(
-              this.class.errorAlertMessage,
-              { debugMessages: this.errors },
-            )
-          }
-
           this.errors = []
         } else {
           this.dom.trigger('Romo.XHR:callQueueSuccess', [this])
-
-          if (this.reloadPageOn === 'complete' || this.reloadPageOn === 'success') {
-            Romo.reloadPage()
-          }
         }
         this.callStarted = false
       }

--- a/lib/components/xhr.js
+++ b/lib/components/xhr.js
@@ -13,11 +13,6 @@ Romo.define('Romo.XHR', function() {
       this._bind()
     }
 
-    // Override as desired.
-    static get errorAlertMessage() {
-      return 'An error has occurred.'
-    }
-
     get callUrl() {
       return this.dom.data('romo-xhr-call-url') || this.dom.attr('href')
     }
@@ -110,7 +105,6 @@ Romo.define('Romo.XHR', function() {
       this.callStarted = false
       this.callRunning = false
       this.currentXHR = this._nullXHR
-      this.errors = []
 
       if (this.disableWithSpinner) {
         this.romoSpinner = new Romo.Spinner(this.dom)
@@ -189,7 +183,6 @@ Romo.define('Romo.XHR', function() {
     }
 
     _onCallError(responseData, status, xhr) {
-      this.errors.push(`[${status}] ${xhr.statusText}: ${responseData}`)
       this.dom.trigger('Romo.XHR:callError', [this, responseData, xhr])
     }
 
@@ -219,13 +212,6 @@ Romo.define('Romo.XHR', function() {
 
     _completeCallQueue() {
       if (this.callStarted) {
-        if (this.errors.length !== 0) {
-          this.dom.trigger('Romo.XHR:callQueueError', [this, this.errors])
-
-          this.errors = []
-        } else {
-          this.dom.trigger('Romo.XHR:callQueueSuccess', [this])
-        }
         this.callStarted = false
       }
 

--- a/lib/utilities/xml_http_request.js
+++ b/lib/utilities/xml_http_request.js
@@ -141,6 +141,8 @@ Romo.define('Romo.XMLHttpRequest', function() {
     // private
 
     _onLoad() {
+      this._showFlashAlerts()
+
       if (this.class.successStatusCode(this.xhr.status)) {
         if (this.onSuccess) {
           if (this.isNonTextResponseType) {
@@ -192,6 +194,36 @@ Romo.define('Romo.XMLHttpRequest', function() {
       if (this.onProgress) {
         this.onProgress(this.xhr)
       }
+    }
+
+    _showFlashAlerts() {
+      var flashAlerts = []
+      if (this._getDomain(window.location) === this._getDomain(this.url)) {
+        flashAlerts.push(Romo.FlashAlert.forXHR(this.xhr))
+      }
+
+      if (
+        this.xhr.responseType === this.class.JSON &&
+        this.xhr.response &&
+        this.xhr.response.flashAlerts &&
+        this.xhr.response.flashAlerts.length !== 0
+      ) {
+        flashAlerts.concat(
+          this.xhr.response.flashAlerts.map(function(flashAlertObject) {
+            return new Romo.FlashAlert(flashAlertObject)
+          })
+        )
+      }
+
+      Romo.showFlashAlerts(
+        flashAlerts.filter(function(romoFlashAlert) {
+          return romoFlashAlert.isMessagePresent
+        })
+      )
+    }
+
+    _getDomain(url) {
+      return new URL(url.toString()).hostname
     }
   }
 })

--- a/lib/utilities/xml_http_request.js
+++ b/lib/utilities/xml_http_request.js
@@ -54,8 +54,24 @@ Romo.define('Romo.XMLHttpRequest', function() {
       return 'complete'
     }
 
+    static get ARRAYBUFFER() {
+      return 'arraybuffer'
+    }
+
+    static get BLOB() {
+      return 'blob'
+    }
+
+    static get DOCUMENT() {
+      return 'document'
+    }
+
     static get JSON() {
       return 'json'
+    }
+
+    static get TEXT() {
+      return 'text'
     }
 
     static get defaultXHRMethod() {
@@ -76,10 +92,17 @@ Romo.define('Romo.XMLHttpRequest', function() {
 
     get isNonTextResponseType() {
       return (
-        this.responseType === 'arraybuffer' ||
-        this.responseType === 'blob' ||
-        this.responseType === 'document' ||
+        this.responseType === this.class.ARRAYBUFFER ||
+        this.responseType === this.class.BLOB ||
+        this.responseType === this.class.DOCUMENT ||
         this.responseType === this.class.JSON
+      )
+    }
+
+    get isBinaryResponseType() {
+      return (
+        this.responseType === this.class.ARRAYBUFFER ||
+        this.responseType === this.class.BLOB
       )
     }
 
@@ -173,12 +196,19 @@ Romo.define('Romo.XMLHttpRequest', function() {
     }
 
     _onError() {
+      const response =
+        this.isNonTextResponseType ? this.xhr.response : this.xhr.responseText
+
+      if (this.isBinaryResponseType) {
+        this.errorResponseText = `${this.xhr.status} ${this.xhr.statusText}`
+      } else if (this.responseType === this.class.JSON) {
+        this.errorResponseText = JSON.stringify(response)
+      } else {
+        this.errorResponseText = response.toString()
+      }
+
       if (this.onError) {
-        if (this.isNonTextResponseType) {
-          this.onError(this.xhr.response, this.xhr.status, this.xhr)
-        } else {
-          this.onError(this.xhr.responseText, this.xhr.status, this.xhr)
-        }
+        this.onError(response, this.xhr.status, this.xhr)
       }
     }
 

--- a/lib/utilities/xml_http_request.js
+++ b/lib/utilities/xml_http_request.js
@@ -11,6 +11,7 @@ Romo.define('Romo.XMLHttpRequest', function() {
       onCallStart,
       onCallEnd,
       onProgress,
+      reloadPageOn,
       headers,
       contentType,
       responseType,
@@ -27,15 +28,30 @@ Romo.define('Romo.XMLHttpRequest', function() {
       this.onCallStart = onCallStart
       this.onCallEnd = onCallEnd
       this.onProgress = onProgress
+      this.reloadPageOn = reloadPageOn
       this.headers = headers
       this.contentType = contentType
       this.responseType = responseType
       this.username = username
       this.password = password
+
+      this.errorResponseText = undefined
     }
 
     static get GET() {
       return 'GET'
+    }
+
+    static get SUCCESS() {
+      return 'success'
+    }
+
+    static get ERROR() {
+      return 'error'
+    }
+
+    static get COMPLETE() {
+      return 'complete'
     }
 
     static get JSON() {
@@ -187,6 +203,30 @@ Romo.define('Romo.XMLHttpRequest', function() {
     _onCallEnd() {
       if (this.onCallEnd) {
         this.onCallEnd(this.xhr)
+      }
+
+      if (this.errorResponseText) {
+        if (
+          this.reloadPageOn === this.class.COMPLETE ||
+            this.reloadPageOn === this.class.ERROR
+        ) {
+          Romo.alertAndReloadPage(
+            Romo.xhrErrorAlertMessage(),
+            { debugMessage: this.errorResponseText },
+          )
+        } else {
+          Romo.alert(
+            Romo.xhrErrorAlertMessage(),
+            { debugMessage: this.errorResponseText },
+          )
+        }
+      } else {
+        if (
+          this.reloadPageOn === this.class.COMPLETE ||
+            this.reloadPageOn === this.class.SUCCESS
+        ) {
+          Romo.reloadPage()
+        }
       }
     }
 

--- a/test/dom_components/xhr_tests.html
+++ b/test/dom_components/xhr_tests.html
@@ -6,7 +6,7 @@
   </style>
 </head>
 <body>
-  <h1>Romo.Spinner system tests</h1>
+  <h1>Romo.XHR system tests</h1>
   <button href="https://api.github.com/repos/redding/romo-js"
           data-romo-xhr>
     Example 1 (GET JSON via href)
@@ -126,15 +126,6 @@
       })
       .on('Romo.XHR:callEnd', function(e, romoXHR, xhr) {
         statusDOM.appendHTML('<div>-> end</div>')
-      })
-      .on('Romo.XHR:callQueueSuccess', function(e, romoXHR) {
-        statusDOM.appendHTML('<div>-> queue success</div>')
-      })
-      .on('Romo.XHR:callQueueError', function(e, romoXHR, errors) {
-        statusDOM.appendHTML('<div>-> queue error</div>')
-        statusDOM.appendHTML(`<code>${errors.toString()}</code>`)
-        console.log('-> queue error, errors:')
-        console.log(errors)
       })
       .on('Romo.XHR:callQueueEnd', function(e, romoXHR) {
         statusDOM.appendHTML('<div>-> queue end</div>')

--- a/test/system_tests.html
+++ b/test/system_tests.html
@@ -972,14 +972,14 @@
 
         const flashAlertObjects =
           [
-            {
+            new Romo.FlashAlert({
               alertType: 'notice',
               message: 'message 1',
-            },
-            {
+            }),
+            new Romo.FlashAlert({
               alertType: 'error',
               message: 'message 2',
-            },
+            }),
           ]
         Romo.showFlashAlerts(flashAlertObjects)
         test.assert(console.errorMessages.length === 1)

--- a/test/system_tests.html
+++ b/test/system_tests.html
@@ -921,23 +921,23 @@
         test.unstubConsoleError()
       })
 
-      tests.test('<code>Romo.alert</code> given empty debugMessages', function(test) {
+      tests.test('<code>Romo.alert</code> no debugMessage', function(test) {
         test.stubConsoleError()
 
-        Romo.alert('test alert message', { debugMessages: [] })
+        Romo.alert('test alert message')
         test.assert(console.errorMessages.length === 1)
         test.assert(console.errorMessages[0][0] === 'test alert message')
 
         test.unstubConsoleError()
       })
 
-      tests.test('<code>Romo.alert</code> given non-empty debugMessages', function(test) {
+      tests.test('<code>Romo.alert</code> given a debugMessage', function(test) {
         test.stubConsoleError()
 
-        Romo.alert('test alert message', { debugMessages: ['debug 1', 'debug 2'] })
+        Romo.alert('test alert message', { debugMessage: 'debug 1' })
         test.assert(console.errorMessages.length === 1)
         test.assert(
-          console.errorMessages[0][0] === 'test alert message:\ndebug 1\ndebug 2'
+          console.errorMessages[0][0] === 'test alert message:\ndebug 1'
         )
 
         test.unstubConsoleError()


### PR DESCRIPTION
These are a number of reworks I noticed while implementing the coming Romo.Form component's XHR handling.

### move flash alert handling into Romo.XMLHttpRequest utility handling

This ensures that any XHR made via Romo will support flash alerts.
This is prep for adding a Romo.Form component that does XHR
submissions and wants this behavior.

### rename Romo.XHR `_onCall` -> `_onCallOn`

This is a more accurate method name. I noticed this while
refactoring Romo.XHR in prep for adding a Romo.Form component.

### move XHR `reloadPageOn` behavior to Romo.XMLHttpRequest utility

This is commonization in prep for adding a Romo.Form component that
does XHR submissions and wants this behavior.

### move XHR error handling to Romo.XMLHttpRequest utility

This is commonization in prep for adding a Romo.Form utility that
wants this behavior. As a side effect, the Romo.XHR component
no longer supports the "queue success/error" events.

This also reworks the alert functions to make their behavior more
easily overridable.