### PR TITLE
add Romo.Form DOM component

### DIFF
--- a/lib/api/define.js
+++ b/lib/api/define.js
@@ -13,7 +13,7 @@
 //     somePublicMethod() {
 //     }
 //
-//     // Private
+//     // private
 //
 //     _somePrivateMethod() {
 //     }
@@ -64,7 +64,7 @@ Romo.namespace =
 //     somePublicMethod() {
 //     }
 //
-//     // Private
+//     // private
 //
 //     _somePrivateMethod() {
 //     }

--- a/lib/api/dom_attributes.js
+++ b/lib/api/dom_attributes.js
@@ -7,7 +7,7 @@ Romo.attr =
 Romo.setAttr =
   function(elements, attributeName, attributeValue) {
     const value = String(attributeValue)
-    Romo.dom(elements).forEach(function(element) {
+    Romo.dom(elements).forEachElement(function(element) {
       element.setAttribute(attributeName, value)
     })
     return elements
@@ -15,7 +15,7 @@ Romo.setAttr =
 
 Romo.rmAttr =
   function(elements, attributeName) {
-    Romo.dom(elements).forEach(function(element) {
+    Romo.dom(elements).forEachElement(function(element) {
       element.removeAttribute(attributeName)
     })
     return elements
@@ -43,7 +43,7 @@ Romo.style =
 
 Romo.setStyle =
   function(elements, styleName, styleValue) {
-    Romo.dom(elements).forEach(function(element) {
+    Romo.dom(elements).forEachElement(function(element) {
       element.style[styleName] = styleValue
     })
     return elements
@@ -52,14 +52,14 @@ Romo.setStyle =
 Romo.batchSetStyle =
   function(elements, styles) {
     for (var styleName in styles) {
-      Romo.setStyle(Romo.dom(elements), styleName, styles[styleName])
+      Romo.setStyle(elements, styleName, styles[styleName])
     }
     return elements
   }
 
 Romo.rmStyle =
   function(elements, styleName) {
-    Romo.dom(elements).forEach(function(element) {
+    Romo.dom(elements).forEachElement(function(element) {
       element.style[styleName] = ''
     })
     return elements
@@ -88,7 +88,7 @@ Romo.addClass =
   function(elements, className) {
     const splitClassNames =
       className.split(' ').filter(function(n) { return n })
-    Romo.dom(elements).forEach(function(element) {
+    Romo.dom(elements).forEachElement(function(element) {
       splitClassNames.forEach(function(splitClassName) {
         element.classList.add(splitClassName)
       })
@@ -100,7 +100,7 @@ Romo.rmClass =
   function(elements, className) {
     const splitClassNames =
       className.split(' ').filter(function(n) { return n })
-    Romo.dom(elements).forEach(function(element) {
+    Romo.dom(elements).forEachElement(function(element) {
       splitClassNames.forEach(function(splitClassNames) {
         element.classList.remove(splitClassNames)
       })
@@ -112,7 +112,7 @@ Romo.toggleClass =
   function(elements, className) {
     const splitClassNames =
       className.split(' ').filter(function(n) { return n })
-    Romo.dom(elements).forEach(function(element) {
+    Romo.dom(elements).forEachElement(function(element) {
       splitClassNames.forEach(function(splitClassNames) {
         element.classList.toggle(splitClassNames)
       })
@@ -122,7 +122,7 @@ Romo.toggleClass =
 
 Romo.show =
   function(elements) {
-    Romo.dom(elements).forEach(function(element) {
+    Romo.dom(elements).forEachElement(function(element) {
       element.style.display = ''
     })
     return elements
@@ -130,7 +130,7 @@ Romo.show =
 
 Romo.hide =
   function(elements) {
-    Romo.dom(elements).forEach(function(element) {
+    Romo.dom(elements).forEachElement(function(element) {
       element.style.display = 'none'
     })
     return elements
@@ -208,7 +208,7 @@ Romo.scrollLeft =
 
 Romo.setScrollTop =
   function(elements, value) {
-    Romo.dom(elements).forEach(function(element) {
+    Romo.dom(elements).forEachElement(function(element) {
       if ('scrollTop' in element) {
         element.scrollTop = value
       } else {
@@ -220,7 +220,7 @@ Romo.setScrollTop =
 
 Romo.setScrollLeft =
   function(elements, value) {
-    Romo.dom(elements).forEach(function(element) {
+    Romo.dom(elements).forEachElement(function(element) {
       if ('scrollLeft' in element) {
         element.scrollLeft = value
       } else {

--- a/lib/api/dom_events.js
+++ b/lib/api/dom_events.js
@@ -15,7 +15,7 @@ Romo.on =
     Romo.fid(eventHandlerFn)
     Romo.fid(listenerFn, { aliasFn: eventHandlerFn })
 
-    Romo.dom(elements).forEach(Romo.bind(function(element) {
+    Romo.dom(elements).forEachElement(Romo.bind(function(element) {
       Romo.env.addEventListener(element, eventName, listenerFn)
     }, this))
 
@@ -24,7 +24,7 @@ Romo.on =
 
 Romo.off =
   function(elements, eventName, eventHandlerFn) {
-    Romo.dom(elements).forEach(Romo.bind(function(element) {
+    Romo.dom(elements).forEachElement(Romo.bind(function(element) {
       Romo.env.removeEventListener(element, eventName, eventHandlerFn)
     }, this))
 
@@ -36,7 +36,7 @@ Romo.trigger =
     const event =
       new CustomEvent(customEventName, { bubbles: false, detail: args })
 
-    Romo.dom(elements).forEach(function(element) {
+    Romo.dom(elements).forEachElement(function(element) {
       // Use pushFn to make event dispatches asynchronous like "native" events
       // (`dispatchEvent` runs event handlers synchronously).
       Romo.pushFn(function() { element.dispatchEvent(event) })

--- a/lib/api/dom_mutate.js
+++ b/lib/api/dom_mutate.js
@@ -10,7 +10,7 @@ Romo.setInnerHTML =
 
 Romo.remove =
   function(elements) {
-    return Romo.dom(elements).map(function(element) {
+    return Romo.dom(elements).mapElements(function(element) {
       if (element.parentElement) {
         element.parentElement.removeChild(element)
       }
@@ -20,7 +20,7 @@ Romo.remove =
 
 Romo.removeChildren =
   function(parentElements) {
-    return Romo.dom(parentElements).map(function(parentElement) {
+    return Romo.dom(parentElements).mapElements(function(parentElement) {
       Romo.children(parentElement).forEach(function(childElement) {
         parentElement.removeChild(childElement)
       })
@@ -92,7 +92,7 @@ Romo.prepend =
     var referenceElement = dom.firstElement.firstChild
     return (
       childDOM
-        .reverseMap(function(childElement) {
+        .reverseMapElements(function(childElement) {
           referenceElement =
             dom.firstElement.insertBefore(childElement, referenceElement)
           return Romo.env.applyAutoInitTo(referenceElement)
@@ -115,7 +115,7 @@ Romo.append =
     const dom = Romo.dom(element)
     const childDOM = Romo.dom(childElements)
     return (
-      childDOM.map(function(childElement) {
+      childDOM.mapElements(function(childElement) {
         dom.firstElement.appendChild(childElement)
         return Romo.env.applyAutoInitTo(childElement)
       })
@@ -139,7 +139,7 @@ Romo.before =
     var referenceElement = dom.firstElement
     return (
       siblingDOM
-        .reverseMap(function(siblingElement) {
+        .reverseMapElements(function(siblingElement) {
           referenceElement =
             parentElement.insertBefore(siblingElement, referenceElement)
           return Romo.env.applyAutoInitTo(referenceElement)
@@ -164,7 +164,7 @@ Romo.after =
     const parentElement = Romo.parent(dom)
     var referenceElement = Romo.next(element)
     return (
-      siblingDOM.map(function(siblingElement) {
+      siblingDOM.mapElements(function(siblingElement) {
         parentElement.insertBefore(siblingElement, referenceElement)
         return Romo.env.applyAutoInitTo(siblingElement)
       })

--- a/lib/api/dom_query.js
+++ b/lib/api/dom_query.js
@@ -46,11 +46,13 @@ Romo.f =
 Romo.find =
   function(parentElements, selector) {
     return Romo.dom(
-      Romo.dom(parentElements).reduce(function(foundElements, parentElement) {
-        return foundElements.concat(
-          Romo.array(parentElement.querySelectorAll(selector))
-        )
-      }, [])
+      Romo
+        .dom(parentElements)
+        .reduceElements(function(foundElements, parentElement) {
+          return foundElements.concat(
+            Romo.array(parentElement.querySelectorAll(selector))
+          )
+        }, [])
     )
   }
 

--- a/lib/components.js
+++ b/lib/components.js
@@ -1,2 +1,3 @@
+import './components/form.js'
 import './components/spinner.js'
 import './components/xhr.js'

--- a/lib/components/form.js
+++ b/lib/components/form.js
@@ -1,0 +1,232 @@
+import './dom_component.js'
+import './form/browser_submission.js'
+import './form/enter_submit.js'
+import './form/event_submission.js'
+import './form/first_visible_input.js'
+import './form/on_change_submits.js'
+import './form/submit_spinners.js'
+import './form/submits.js'
+import './form/xhr_get_submission.js'
+import './form/xhr_post_submission.js'
+
+// Romo.Form extends form DOM elements with XHR submit and other custom
+// behaviors. It uses DOM data attributes with auto-initialization for
+// configuration. It emits status and submission lifecycle events.
+Romo.define('Romo.Form', function() {
+  return class extends Romo.DOMComponent {
+    constructor(dom, { givenSubmits, givenSubmitSpinners } = {}) {
+      super(dom)
+
+      this.givenSubmitsDOM = Romo.dom(givenSubmits)
+      this.givenSubmitSpinnersDOM = Romo.dom(givenSubmitSpinners)
+
+      // Delay the initial binding so nested components have time to bind first.
+      Romo.pushFn(Romo.bind(this._bind, this))
+    }
+
+    static doTriggerAddValidationMessages(formDOM, messages) {
+      formDOM.trigger('Romo.Form:triggerAddValidationMessages', [messages])
+    }
+
+    static doTriggerRemoveValidationMessages(formDOM) {
+      formDOM.trigger('Romo.Form:triggerRemoveErrorMessages')
+    }
+
+    get submission() {
+      if (this._submission === undefined) {
+        if (this.usesBrowserSubmission) {
+          this._submission = new Romo.Form.BrowserSubmission(this.dom)
+        } else if (this.usesEventSubmission) {
+          this._submission = new Romo.Form.EventSubmission(this.dom)
+        } else if (this.usesXHRGetSubmission) {
+          this._submission = new Romo.Form.XHRGetSubmission(this.dom)
+        } else {
+          this._submission = new Romo.Form.XHRPostSubmission(this.dom)
+        }
+      }
+      return this._submission
+    }
+
+    get usesBrowserSubmission() {
+      return this.dom.data('romo-form-browser-submit') === true
+    }
+
+    get usesEventSubmission() {
+      return this.dom.data('romo-form-event-submit') === true
+    }
+
+    get usesXHRGetSubmission() {
+      return (
+        !this.usesBrowserSubmission &&
+        !this.usesEventSubmission &&
+        this.dom.attr('method').toUpperCase() === Romo.XMLHttpRequest.GET
+      )
+    }
+
+    doSubmit() {
+      this.submission.doCall()
+
+      return this
+    }
+
+    doConfirmSubmit() {
+      if (!this.submission.isRunning) {
+        throw new Error(
+          'RuntimeError: no submission to confirm. Did you call `#doSubmit()` first?'
+        )
+      }
+
+      this.submission.doStartSubmit()
+
+      return this
+    }
+
+    doDenySubmit() {
+      if (!this.submission.isRunning) {
+        throw new Error(
+          'RuntimeError: no submission to deny. Did you call `#doSubmit()` first?'
+        )
+      }
+
+      this.submission.doCompleteSubmit()
+
+      return this
+    }
+
+    doFocusFirstVisibleInput() {
+      (new Romo.Form.FirstVisibleInput(this.dom)).doFocus()
+
+      return this
+    }
+
+    doEnableSubmits() {
+      this.romoFormSubmits.doEnable()
+
+      return this
+    }
+
+    doDisableSubmits() {
+      this.romoFormSubmits.doDisable()
+
+      return this
+    }
+
+    doStartSubmitSpinners() {
+      this.romoFormSubmitSpinners.doStart()
+
+      return this
+    }
+
+    doStopSubmitSpinners() {
+      this.romoFormSubmitSpinners.doStop()
+
+      return this
+    }
+
+    // private
+
+    _bind() {
+      this.romoFormSubmits =
+        new Romo.Form.Submits(
+          this.dom,
+          { givenSubmitsDOM: this.givenSubmitsDOM },
+        )
+      this.romoFormSubmitSpinners =
+        new Romo.Form.SubmitSpinners(
+          this.dom,
+          { givenSubmitSpinnersDOM: this.givenSubmitSpinnersDOM },
+        )
+      this.romoFormOnChangeSubmits = new Romo.Form.OnChangeSubmits(this.dom)
+      this.romoFormEnterSubmit = new Romo.Form.EnterSubmit(this.dom)
+
+      this._bindForm()
+
+      this.class.doTriggerRemoveValidationMessages(this.dom)
+      this.doFocusFirstVisibleInput()
+    }
+
+    _bindForm() {
+      // Submit Trigger events
+
+      this.dom.on('Romo.Form:triggerSubmit', Romo.bind(function(e) {
+        if (!this.romoFormSubmits.areDisabled) {
+          this.submission.doCall()
+        }
+      }, this))
+
+      this.dom.on(
+        'Romo.Form.Submits:clicked',
+        Romo.bind(function(e, _, clickedSubmitDOM) {
+          if (!Romo.Form.Submits.isDisabled(clickedSubmitDOM)) {
+            this.dom.trigger('Romo.Form:triggerSubmit')
+          }
+        }, this)
+      )
+
+      this.dom.on('Romo.Form.OnChangeSubmits:changed', Romo.bind(function(e) {
+        this.dom.trigger('Romo.Form:triggerSubmit')
+      }, this))
+
+      this.dom.on('Romo.Form.EnterSubmit:pressed', Romo.bind(function(e) {
+        this.dom.trigger('Romo.Form:triggerSubmit')
+      }, this))
+
+      // Submission Events
+
+      this._proxySubmissionLifecycleEvents(
+        'beforeSubmit',
+        'afterSubmit',
+        'confirmSubmit',
+        'browserSubmit',
+        'xhrSubmit',
+        'eventSubmit',
+        'submitSuccess',
+        'submitError',
+        'submitComplete'
+      )
+
+      // Lifecycle events
+
+      this.dom.on('Romo.Form:beforeSubmit', Romo.bind(function(e, romoForm) {
+        this.doDisableSubmits()
+      }, this))
+
+      this.dom.on('Romo.Form:browserSubmit', Romo.bind(function(e, romoForm) {
+        this.doEnableSubmits()
+      }, this))
+
+      this.dom.on('Romo.Form:submitComplete', Romo.bind(function(e, romoForm) {
+        this.doEnableSubmits()
+      }, this))
+
+      // Trigger Events
+
+      this.dom.on('Romo.Form:triggerSubmitSpinnersStart', Romo.bind(function(e) {
+        this.doStartSubmitSpinners()
+      }, this))
+
+      this.dom.on('Romo.Form:triggerSubmitSpinnersStop', Romo.bind(function(e) {
+        this.doStopSubmitSpinners()
+      }, this))
+    }
+
+    _proxySubmissionLifecycleEvents(...eventNames) {
+      var submissionEventName, formEventName
+
+      eventNames.forEach(Romo.bind(function(eventName) {
+        submissionEventName = `Romo.Form.Submission:${eventName}`
+        formEventName = `Romo.Form:${eventName}`
+
+        Romo.proxyEvent({
+          fromElement:   this.dom,
+          toElement:     this.dom,
+          fromEventName: submissionEventName,
+          toEventName:   formEventName,
+          toArgs:        [this],
+        })
+      }, this))
+    }
+  }
+})
+
+Romo.addAutoInitSelector('[data-romo-form]', Romo.Form)

--- a/lib/components/form/base_submission.js
+++ b/lib/components/form/base_submission.js
@@ -1,0 +1,85 @@
+import '../dom_component.js'
+
+Romo.define('Romo.Form.BaseSubmission', function() {
+  return class extends Romo.DOMComponent {
+    constructor(formDOM) {
+      super(formDOM)
+
+      this.formDOM = formDOM
+      this.queued = false
+      this.running = false
+    }
+
+    get usesConfirmation() {
+      return this.dom.data('romo-form-confirm-submit') === true
+    }
+
+    get isRunning() {
+      return this.running === true
+    }
+
+    get isQueued() {
+      return this.queued === true
+    }
+
+    get reloadPageOn() {
+      return this.formDOM.data('romo-form-reload-page-on')
+    }
+
+    doCall(fnSubmit) {
+      this.queued = true
+      if (!this.isRunning) {
+        this.running = true
+        this.queued = false
+
+        this.formDOM.trigger('Romo.Form:triggerSubmitSpinnersStart')
+        this.formDOM.trigger('Romo.Form.Submission:beforeSubmit')
+
+        if (this.usesConfirmation) {
+          this.doConfirmSubmit()
+        } else {
+          this.doStartSubmit()
+        }
+      }
+
+      return this
+    }
+
+    doStartSubmit(fnSubmit) {
+      if (!fnSubmit) {
+        throw new Error(
+          `ArgumentError: expected a function for \`fnSubmit\`; given ${fnSubmit}`
+        )
+      }
+
+      if (!this.isRunning) {
+        throw new Error(
+          'RuntimeError: the submission is not running.'
+        )
+      }
+
+      Romo.bind(fnSubmit, this)()
+
+      this.formDOM.trigger('Romo.Form.Submission:afterSubmit')
+
+      return this
+    }
+
+    doConfirmSubmit() {
+      this.formDOM.trigger('Romo.Form.Submission:confirmSubmit')
+
+      return this
+    }
+
+    doCompleteSubmit() {
+      this.formDOM.trigger('Romo.Form.Submission:submitComplete')
+
+      this.running = false
+      if (this.isQueued) {
+        this.doCall()
+      }
+
+      return this
+    }
+  }
+})

--- a/lib/components/form/base_submission.js
+++ b/lib/components/form/base_submission.js
@@ -39,6 +39,7 @@ Romo.define('Romo.Form.BaseSubmission', function() {
           this.doConfirmSubmit()
         } else {
           this.doStartSubmit()
+          this.formDOM.trigger('Romo.Form.Submission:afterSubmit')
         }
       }
 
@@ -46,23 +47,7 @@ Romo.define('Romo.Form.BaseSubmission', function() {
     }
 
     doStartSubmit(fnSubmit) {
-      if (!fnSubmit) {
-        throw new Error(
-          `ArgumentError: expected a function for \`fnSubmit\`; given ${fnSubmit}`
-        )
-      }
-
-      if (!this.isRunning) {
-        throw new Error(
-          'RuntimeError: the submission is not running.'
-        )
-      }
-
-      Romo.bind(fnSubmit, this)()
-
-      this.formDOM.trigger('Romo.Form.Submission:afterSubmit')
-
-      return this
+      this._startSubmit(fnSubmit)
     }
 
     doConfirmSubmit() {
@@ -78,6 +63,26 @@ Romo.define('Romo.Form.BaseSubmission', function() {
       if (this.isQueued) {
         this.doCall()
       }
+
+      return this
+    }
+
+    // private
+
+    _startSubmit(fnSubmit) {
+      if (!fnSubmit) {
+        throw new Error(
+          `ArgumentError: expected a function for \`fnSubmit\`; given ${fnSubmit}`
+        )
+      }
+
+      if (!this.isRunning) {
+        throw new Error(
+          'RuntimeError: the submission is not running.'
+        )
+      }
+
+      Romo.bind(fnSubmit, this)()
 
       return this
     }

--- a/lib/components/form/base_xhr_submission.js
+++ b/lib/components/form/base_xhr_submission.js
@@ -5,6 +5,14 @@ import './base_submission.js'
 // It handles all other XHR error responses by alerting using `Romo.alert`.
 Romo.define('Romo.Form.BaseXHRSubmission', function() {
   return class extends Romo.Form.BaseSubmission {
+    get callURL() {
+      return this.formDOM.attr('action')
+    }
+
+    get callMethod() {
+      return this.formDOM.attr('method')
+    }
+
     get responseType() {
       return (
         this.formDOM.data('romo-form-xhr-response-type') ||
@@ -18,8 +26,8 @@ Romo.define('Romo.Form.BaseXHRSubmission', function() {
 
     doStartSubmit(submitXHROptions) {
       const requiredXHROptions = {
-        url:          this.formDOM.attr('action'),
-        method:       this.formDOM.attr('method'),
+        url:          this.callURL,
+        method:       this.callMethod,
         responseType: this.responseType,
         reloadPageOn: this.reloadPageOn,
         onSuccess:    Romo.bind(this._onSuccess, this),

--- a/lib/components/form/base_xhr_submission.js
+++ b/lib/components/form/base_xhr_submission.js
@@ -1,0 +1,66 @@
+import './base_submission.js'
+
+// Romo.Form.BaseXHRSubmission submits an Romo.Form using an XHR request. It
+// handles 422 responses by adding/removing validation error messages as needed.
+// It handles all other XHR error responses by alerting using `Romo.alert`.
+Romo.define('Romo.Form.BaseXHRSubmission', function() {
+  return class extends Romo.Form.BaseSubmission {
+    get responseType() {
+      return (
+        this.formDOM.data('romo-form-xhr-response-type') ||
+          Romo.XMLHttpRequest.JSON
+      )
+    }
+
+    get usesJSONResponseType() {
+      return this.responseType === Romo.XMLHttpRequest.JSON
+    }
+
+    doStartSubmit(submitXHROptions) {
+      const requiredXHROptions = {
+        url:          this.formDOM.attr('action'),
+        method:       this.formDOM.attr('method'),
+        responseType: this.responseType,
+        reloadPageOn: this.reloadPageOn,
+        onSuccess:    Romo.bind(this._onSuccess, this),
+        onError:      Romo.bind(this._onError, this),
+        onCallEnd:    Romo.bind(this._onCallEnd, this),
+      }
+
+      return super.doStartSubmit(function() {
+        try {
+          const xhrOptions =
+            Object.assign({}, submitXHROptions, requiredXHROptions)
+          Romo.xhr(xhrOptions)
+          this.formDOM.trigger('Romo.Form.Submission:xhrSubmit', [xhrOptions])
+        } catch (error) {
+          console.error(error)
+          Romo.pushFn(Romo.bind(function() { this._onCallEnd() }, this))
+        }
+      })
+    }
+
+    // private
+
+    _onSuccess(response, status, xhr) {
+      Romo.Form.doTriggerRemoveValidationMessages(this.formDOM)
+
+      this.formDOM.trigger('Romo.Form.Submission:submitSuccess', [response, xhr])
+    }
+
+    _onError(response, status, xhr) {
+      Romo.Form.doTriggerRemoveValidationMessages(this.formDOM)
+
+      if (xhr.status === 422 && xhr.responseJSON) {
+        Romo.Form.doTriggerAddValidationMessages(this.formDOM, xhr.responseJSON)
+      }
+
+      this.formDOM.trigger('Romo.Form.Submission:submitError', [response, xhr])
+      this.formDOM.trigger('Romo.Form:triggerSubmitSpinnersStop')
+    }
+
+    _onCallEnd(xhr) {
+      this.doCompleteSubmit()
+    }
+  }
+})

--- a/lib/components/form/browser_submission.js
+++ b/lib/components/form/browser_submission.js
@@ -1,0 +1,14 @@
+import './base_submission.js'
+
+// Romo.Form.BrowserSubmission submits an Romo.Form using the native browser.
+Romo.define('Romo.Form.BrowserSubmission', function() {
+  return class extends Romo.Form.BaseSubmission {
+    doStartSubmit() {
+      return super.doStartSubmit(function() {
+        this.formDOM.trigger('Romo.Form.Submission:browserSubmit')
+        this.formDOM.firstElement.submit()
+        Romo.pushFn(Romo.bind(function() { this.doCompleteSubmit() }, this))
+      })
+    }
+  }
+})

--- a/lib/components/form/enter_submit.js
+++ b/lib/components/form/enter_submit.js
@@ -1,0 +1,50 @@
+import '../dom_component.js'
+
+Romo.define('Romo.Form.EnterSubmit', function() {
+  return class extends Romo.DOMComponent {
+    constructor(formDOM) {
+      super(formDOM)
+
+      this.formDOM = formDOM
+
+      this._bind()
+    }
+
+    static get enterKeyCode() {
+      return 13 // Enter
+    }
+
+    isEnabled(event) {
+      return (
+        this.formDOM.data('romo-form-disable-enter-submit') !== true &&
+        Romo.dom(event.target).data('romo-form-disable-enter-submit') !== true
+      )
+    }
+
+    isEnterKeyPress(event) {
+      return event.keyCode === this.class.enterKeyCode
+    }
+
+    isValidKeyPress(event) {
+      return (
+        this.isEnterKeyPress(event) &&
+        this.isEnabled(event) &&
+        event.target.nodeName.toLowerCase() !== 'textarea'
+      )
+    }
+
+    // private
+
+    _bind() {
+      this.formDOM.on('keypress', Romo.bind(function(e) {
+        if (this.isValidKeyPress(e)) {
+          e.preventDefault()
+          this.formDOM.trigger(
+            'Romo.Form.EnterSubmit:pressed',
+            [this, Romo.dom(event.target)]
+          )
+        }
+      }, this))
+    }
+  }
+})

--- a/lib/components/form/event_submission.js
+++ b/lib/components/form/event_submission.js
@@ -1,0 +1,27 @@
+import './base_submission.js'
+import './values.js'
+
+// Romo.Form.EventSubmission submits an Romo.Form by just emitting a confirmation
+// event. The Romo.Form consumer should listen for the event, do whatever logic
+// necessary to confirm the submission, and then call `#doSubmit()` on the
+// yielded Romo.Form instance.
+//
+// @example
+//   formDOM.on('Romo.Form:confirmSubmit', function(e, romoForm) {
+//     if (window.confirm('Are you sure?')) {
+//       romoForm.doSubmit()
+//     }
+//   })
+Romo.define('Romo.Form.EventSubmission', function() {
+  return class extends Romo.Form.BaseSubmission {
+    doStartSubmit() {
+      return super.doStartSubmit(function() {
+        this.formDOM.trigger(
+          'Romo.Form.Submission:eventSubmit',
+          [Romo.Form.Values.dataSet(this.formDOM, { includeFiles: true })]
+        )
+        Romo.pushFn(Romo.bind(function() { this.doCompleteSubmit() }, this))
+      })
+    }
+  }
+})

--- a/lib/components/form/first_visible_input.js
+++ b/lib/components/form/first_visible_input.js
@@ -1,0 +1,51 @@
+Romo.define('Romo.Form.FirstVisibleInput', function() {
+  return class {
+    constructor(formDOM) {
+      this.formDOM = formDOM
+    }
+
+    static get visibleInputsSelector() {
+      return (
+        'input:not([type="hidden"]):not([type="file"]), ' +
+        'select, ' +
+        'textarea'
+      )
+    }
+
+    get visibleInputDOMs() {
+      return Romo.memoize(this, 'visibleInputDOMs', function() {
+        return (
+          this.formDOM
+            .find(this.class.visibleInputsSelector)
+            .filter(function(inputDOM) {
+              return inputDOM.css('display') !== 'none'
+            })
+        )
+      })
+    }
+
+    get focusOnInitInputDOMs() {
+      return Romo.memoize(this, 'focusOnInitInputsDOM', function() {
+        return this.visibleInputDOMs.filter(function(inputDOM) {
+          return inputDOM.data('romo-form-focus-on-init') === true
+        })
+      })
+    }
+
+    get isFocusingEnabled() {
+      return (
+        this.formDOM.data('romo-form-disable-focus-on-init') !== true
+      )
+    }
+
+    doFocus() {
+      const focusInputDOM =
+        this.focusOnInitInputDOMs[0] || this.visibleInputDOMs[0]
+      if (this.isFocusingEnabled && focusInputDOM) {
+        Romo.pushFn(function() { focusInputDOM.firstElement.focus() })
+      }
+
+      return this
+    }
+  }
+})

--- a/lib/components/form/on_change_submits.js
+++ b/lib/components/form/on_change_submits.js
@@ -1,0 +1,35 @@
+import '../dom_component.js'
+
+Romo.define('Romo.Form.OnChangeSubmits', function() {
+  return class extends Romo.DOMComponent {
+    constructor(formDOM) {
+      super(formDOM)
+
+      this.formDOM = formDOM
+
+      this._bind()
+    }
+
+    static get selector() {
+      return '[data-romo-form-on-change-submit]'
+    }
+
+    get onChangeSubmitsDOM() {
+      return Romo.memoize(this, 'onChangeSubmitDOMs', function() {
+        return this.formDOM.find(this.class.selector)
+      })
+    }
+
+    // private
+
+    _bind() {
+      this.onChangeSubmitsDOM.on('change', Romo.bind(function(e) {
+        const submitDOM = Romo.dom(e.target).closest(this.class.selector)
+        this.formDOM.trigger(
+          'Romo.Form.OnChangeSubmits:changed',
+          [this, submitDOM]
+        )
+      }, this))
+    }
+  }
+})

--- a/lib/components/form/submit_spinners.js
+++ b/lib/components/form/submit_spinners.js
@@ -1,0 +1,44 @@
+import '../dom_component.js'
+
+Romo.define('Romo.Form.SubmitSpinners', function() {
+  return class extends Romo.DOMComponent {
+    constructor(formDOM, { givenSubmitSpinnersDOM } = {}) {
+      super(formDOM)
+
+      this.formDOM = formDOM
+      this.givenSubmitSpinnersDOM = givenSubmitSpinnersDOM
+    }
+
+    static get selector() {
+      return (
+        'button[type="submit"][data-romo-spinner], ' +
+        'input[type="submit"][data-romo-spinner], ' +
+        '[data-romo-form-submit][data-romo-spinner], ' +
+        '[data-romo-form-submit-spinner][data-romo-spinner]'
+      )
+    }
+
+    get submitSpinnersDOM() {
+      return Romo.memoize(this, 'submitSpinnersDOM', function() {
+        return (
+          Romo
+            .dom()
+            .concat(this.givenSubmitSpinnersDOM)
+            .concat(this.formDOM.find(this.class.selector))
+        )
+      })
+    }
+
+    doStart() {
+      this.submitSpinnersDOM.trigger('Romo.Spinner:triggerStart')
+
+      return this
+    }
+
+    doStop() {
+      this.submitSpinnersDOM.trigger('Romo.Spinner:triggerStop')
+
+      return this
+    }
+  }
+})

--- a/lib/components/form/submits.js
+++ b/lib/components/form/submits.js
@@ -1,0 +1,66 @@
+import '../dom_component.js'
+
+Romo.define('Romo.Form.Submits', function() {
+  return class extends Romo.DOMComponent {
+    constructor(formDOM, { givenSubmitsDOM } = {}) {
+      super(formDOM)
+
+      this.formDOM = formDOM
+      this.givenSubmitsDOM = givenSubmitsDOM
+
+      this._bind()
+    }
+
+    static get selector() {
+      return (
+        'button[type="submit"], input[type="submit"], [data-romo-form-submit]'
+      )
+    }
+
+    static isDisabled(submitDOM) {
+      return submitDOM.hasClass('disabled')
+    }
+
+    get submitsDOM() {
+      return Romo.memoize(this, 'submitsDOM', function() {
+        return (
+          Romo
+            .dom()
+            .concat(this.givenSubmitsDOM)
+            .concat(this.formDOM.find(this.class.selector))
+        )
+      })
+    }
+
+    get areDisbabled() {
+      return (
+        this.submitsDOM.reduce(function(disabled, submitDOM) {
+          return disabled || this.class.isDisables(submitDOM)
+        }, false)
+      )
+    }
+
+    doDisable() {
+      this.submitsDOM.addClass('disabled')
+
+      return this
+    }
+
+    doEnable() {
+      this.submitsDOM.rmClass('disabled')
+
+      return this
+    }
+
+    // private
+
+    _bind() {
+      this.submitsDOM.on('click', Romo.bind(function(e) {
+        e.preventDefault()
+
+        const submitDOM = Romo.dom(e.target).closest(this.class.selector)
+        this.formDOM.trigger('Romo.Form.Submits:clicked', [this, submitDOM])
+      }, this))
+    }
+  }
+})

--- a/lib/components/form/values.js
+++ b/lib/components/form/values.js
@@ -1,0 +1,110 @@
+Romo.define('Romo.Form.Values', function() {
+  return class {
+    constructor(formDOM, { includeFiles } = {}) {
+      this.formDOM = formDOM
+      this.includeFiles = includeFiles || false
+    }
+
+    static dataSet(formDOM, { includeFiles } = {}) {
+      return (new this(formDOM, { includeFiles: includeFiles })).dataSet
+    }
+
+    static formData(formDOM, { includeFiles } = {}) {
+      return (new this(formDOM, { includeFiles: includeFiles })).formData
+    }
+
+    get dataSet() {
+      return Romo.memoize(this, 'dataSet', function() {
+        return this._buildDataSet()
+      })
+    }
+
+    get formData() {
+      return Romo.memoize(this, 'formData', function() {
+        return this._buildFormData()
+      })
+    }
+
+    // private
+
+    _buildDataSet() {
+      var dataSet = {}
+
+      // Build dataSet object from the form element's inputs.
+      // { "inputName1": "inputValue1",
+      //   "inputName2[]": ["inputValue1", "inputValue2"],
+      //   ...
+      // }
+      Romo
+        .array(this.formDOM.firstElement.elements)
+        .forEach(Romo.bind(function(input) {
+          if (this._isAFormValueInput(input)) {
+            if (dataSet[input.name] === undefined) {
+              // Use a Set to ensure only building unique value sets.
+              dataSet[input.name] = new Set()
+            }
+
+            if (input.nodeName.toLowerCase() === 'select') {
+              Romo.array(input.options).filter(function(option) {
+                return option.selected
+              }).forEach(function(selectedOption) {
+                dataSet[input.name].add(selectedOption.value)
+              })
+            } else if (input.type === 'file') {
+              Array.prototype.forEach.call(input.files, function(file) {
+                dataSet[input.name].add(file)
+              })
+            } else if (input.type === 'checkbox') {
+              // Only accumulate checkbox values if they are designated as an
+              // Array value (e.g. name="widget_ids[]").
+              if (!input.name.match(/.+\[\]$/g)) {
+                dataSet[input.name].clear()
+              }
+              dataSet[input.name].add(input.value)
+            } else {
+              dataSet[input.name].add(input.value)
+            }
+          }
+        }, this))
+
+      for (var key in dataSet) {
+        // Convert Set values to Arrays
+        dataSet[key] = Array.from(dataSet[key])
+
+        // Remove the array from any single item values.
+        if (dataSet[key].length === 1) {
+          dataSet[key] = dataSet[key][0]
+        }
+      }
+
+      return dataSet
+    }
+
+    _buildFormData() {
+      const formData = new FormData()
+
+      for (var name in this.dataSet) {
+        Romo.array(this.dataSet[name]).forEach(function(value) {
+          formData.append(name, value)
+        })
+      }
+
+      return formData
+    }
+
+    /* eslint-disable no-multi-spaces */
+    _isAFormValueInput(input) {
+      return (
+        input.nodeName.toLowerCase() !== 'fieldset'   &&
+        input.name                                    &&
+        !input.disabled                               &&
+        input.type !== 'submit'                       &&
+        input.type !== 'reset'                        &&
+        input.type !== 'button'                       &&
+        (this.includeFiles || input.type  !== 'file') &&
+        (input.checked || (input.type !== 'radio' && input.type !== 'checkbox'))
+      )
+    }
+    /* eslint-enable no-multi-spaces */
+  }
+})

--- a/lib/components/form/xhr_get_submission.js
+++ b/lib/components/form/xhr_get_submission.js
@@ -1,0 +1,14 @@
+import './base_xhr_submission.js'
+import './values.js'
+
+// Romo.Form.XHRGetSubmission submits an Romo.Form using an XHR GET request.
+// It ignores any file input values in the form.
+Romo.define('Romo.Form.XHRGetSubmission', function() {
+  return class extends Romo.Form.BaseXHRSubmission {
+    doStartSubmit() {
+      return super.doStartSubmit({
+        data: Romo.Form.Values.dataSet(this.formDOM, { includeFiles: false }),
+      })
+    }
+  }
+})

--- a/lib/components/form/xhr_get_submission.js
+++ b/lib/components/form/xhr_get_submission.js
@@ -2,13 +2,38 @@ import './base_xhr_submission.js'
 import './values.js'
 
 // Romo.Form.XHRGetSubmission submits an Romo.Form using an XHR GET request.
-// It ignores any file input values in the form.
+// By default, it redirects the page with the given form values as URL search
+// parameters, removes blank param values, and decodes the param value sin the
+// URL it redirects to. It ignores any file input values in the form.
 Romo.define('Romo.Form.XHRGetSubmission', function() {
   return class extends Romo.Form.BaseXHRSubmission {
+    get redirectPage() {
+      return this.formDOM.data('romo-form-redirect-page') !== false
+    }
+
+    get removeBlankGetParams() {
+      return this.formDOM.data('romo-form-remove-blank-get-params') || true
+    }
+
+    get decodeGetParams() {
+      return this.formDOM.data('romo-form-decode-get-params') || true
+    }
+
     doStartSubmit() {
-      return super.doStartSubmit({
-        data: Romo.Form.Values.dataSet(this.formDOM, { includeFiles: false }),
-      })
+      const data =
+        Romo.Form.Values.dataSet(this.formDOM, { includeFiles: false })
+      if (this.redirectPage) {
+        return this._startSubmit(function() {
+          const redirectURL =
+            new Romo.URLSearchParams(data, {
+              removeBlanks: this.removeBlankGetParams,
+              decode:       this.decodeGetParams,
+            }).toURL(this.callURL)
+          Romo.redirectPage(redirectURL.toString())
+        })
+      } else {
+        return super.doStartSubmit({ data: data })
+      }
     }
   }
 })

--- a/lib/components/form/xhr_post_submission.js
+++ b/lib/components/form/xhr_post_submission.js
@@ -1,0 +1,16 @@
+import './base_xhr_submission.js'
+import './values.js'
+
+// Romo.Form.XHRPostSubmission submits an Romo.Form using an XHR POST request.
+Romo.define('Romo.Form.XHRPostSubmission', function() {
+  return class extends Romo.Form.BaseXHRSubmission {
+    doStartSubmit() {
+      return super.doStartSubmit({
+        data:
+          Romo.Form.Values.formData(this.formDOM, { includeFiles: true }),
+        processData: false,
+        contentType: false,
+      })
+    }
+  }
+})

--- a/lib/utilities/auto_init.js
+++ b/lib/utilities/auto_init.js
@@ -22,7 +22,7 @@ Romo.define('Romo.AutoInit', function() {
         Romo.dom(
           Romo
             .dom(parentElements)
-            .filter(function(parentDOM) { return Romo.is(parentDOM, selector) })
+            .filter(function(parentDOM) { return parentDOM.is(selector) })
             .concat(Romo.find(parentElements, selector))
         )
       )

--- a/lib/utilities/dom.js
+++ b/lib/utilities/dom.js
@@ -38,23 +38,52 @@ Romo.define('Romo.DOM', function() {
       return Romo.dom(this.lastElement)
     }
 
-    reverse() {
-      return Romo.dom(this.elements.reverse())
-    }
-
-    filter(fn) {
-      return Romo.dom(this.elements.filter(fn))
-    }
-
     concat(elements) {
       return Romo.dom(this.elements.concat(Romo.dom(elements).elements))
     }
 
+    reverse() {
+      return Romo.dom(this.elements.reverse())
+    }
+
+    reverseElements() {
+      return this.reverse.elements
+    }
+
+    filter(fn) {
+      return (
+        this
+          .elements
+          .map(function(element) { return Romo.dom(element) })
+          .filter(fn)
+      )
+    }
+
+    filterElements(fn) {
+      return this.elements.filter(fn)
+    }
+
     forEach(fn) {
+      this
+        .elements
+        .map(function(element) { return Romo.dom(element) })
+        .forEach(fn)
+    }
+
+    forEachElement(fn) {
       this.elements.forEach(fn)
     }
 
     map(fn) {
+      return (
+        this
+          .elements
+          .map(function(element) { return Romo.dom(element) })
+          .map(fn)
+      )
+    }
+
+    mapElements(fn) {
       return this.elements.map(fn)
     }
 
@@ -62,7 +91,20 @@ Romo.define('Romo.DOM', function() {
       return this.reverse().map(fn)
     }
 
+    reverseMapElements(fn) {
+      return this.reverse().mapElements(fn)
+    }
+
     reduce(fn, acc) {
+      return (
+        this
+          .elements
+          .map(function(element) { return Romo.dom(element) })
+          .reduce(fn, acc)
+      )
+    }
+
+    reduceElements(fn, acc) {
       return this.elements.reduce(fn, acc)
     }
 

--- a/lib/utilities/page_mq.js
+++ b/lib/utilities/page_mq.js
@@ -71,7 +71,7 @@ Romo.define('Romo.PageMQ', function() {
       return this
     }
 
-    // Private
+    // private
 
     // If the underlying Queue is empty and told to dequeue, return a no-op
     // function so we won't try to execute `undefined` and don't have to check

--- a/lib/utilities/url_search_params.js
+++ b/lib/utilities/url_search_params.js
@@ -55,12 +55,37 @@ Romo.define('Romo.URLSearchParams', function() {
       return this.urlSearchParams.get(key)
     }
 
+    append(key, value) {
+      return this._appendValue(this.urlSearchParams, key, value)
+    }
+
     toString() {
       if (this.decode) {
         return window.decodeURIComponent(this.urlSearchParams.toString())
       } else {
         return this.urlSearchParams.toString()
       }
+    }
+
+    toURL(givenURLString) {
+      const givenURL = new URL(givenURLString)
+      const seedSearchParams =
+        new this.class({}, {
+          removeBlanks: this.removeBlanks,
+          decode:       this.decode,
+        })
+      const combinedSearchParams =
+        [givenURL.searchParams, this.urlSearchParams]
+          .reduce(function(acc, searchParams) {
+            for (var key of searchParams.keys()) {
+              acc.append(key, searchParams.get(key))
+            }
+            return acc
+          }, seedSearchParams)
+
+      givenURL.search = combinedSearchParams.toString()
+
+      return givenURL
     }
 
     // private

--- a/lib/utilities/xml_http_request.js
+++ b/lib/utilities/xml_http_request.js
@@ -18,6 +18,10 @@ Romo.define('Romo.XMLHttpRequest', function() {
       username,
       password,
     } = {}) {
+      if (url.toString().trim() === '') {
+        throw new Error('Romo.XMLHttpRequest: no URL given.')
+      }
+
       this.method = method
       this.url = url
       this.data = new Romo.XMLHttpRequest.Data(data)

--- a/lib/utilities/xml_http_request.js
+++ b/lib/utilities/xml_http_request.js
@@ -323,26 +323,13 @@ Romo.define('Romo.XMLHttpRequest.Data', function() {
       })
     }
 
-    get urlSearchParams() {
-      return Romo.memoize(this, 'urlSearchParams', function() {
-        return new Romo.URLSearchParams(this.data)
-      })
-    }
-
     toXHRURL(urlString, { method } = {}) {
-      const url = new URL(urlString)
+      var url
 
       if (method === Romo.XMLHttpRequest.GET) {
-        const combinedSearchParams =
-          [url.searchParams, this.urlSearchParams]
-            .reduce(function(acc, searchParams) {
-              for (var key of searchParams.keys()) {
-                acc.append(key, searchParams.get(key))
-              }
-              return acc
-            }, new URLSearchParams())
-
-        url.search = combinedSearchParams.toString()
+        url = new Romo.URLSearchParams(this.data).toURL(urlString)
+      } else {
+        url = new URL(urlString)
       }
 
       return url.toString()

--- a/test/dom_components/form_tests.html
+++ b/test/dom_components/form_tests.html
@@ -1,0 +1,79 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="/support/romo-js/romo.css"/>
+  <style>
+  </style>
+</head>
+<body>
+  <h1>Romo.Form system tests</h1>
+
+  <form action="https://api.github.com/repos/redding/romo-js"
+        method="get"
+        accept-charset="UTF-8"
+        data-xhr-get-json-form
+        data-romo-form
+        data-romo-form-disable-focus-on-init="true">
+    <input type="text" name="value"
+           placeholder="Enter a value.">
+    <button type="submit"
+            data-romo-spinner>Submit</button>
+  </form>
+
+  <div data-form-status>
+  </div>
+</body>
+<script type="module" src="/support/romo-js/romo.js"></script>
+<script type="module" src="/support/tests.js"></script>
+<script type="module">
+  Romo.onReady(function() {
+    const statusDOM = Romo.f('[data-form-status]')
+
+    Romo
+      .f('[data-romo-form]')
+      .on('Romo.Form:submitError', function(e, romoForm, responseData, xhr) {
+        console.log(responseData)
+      })
+      .on('Romo.Form:beforeSubmit', function(e, romoForm) {
+        statusDOM.clearHTML()
+        statusDOM.appendHTML('<div>-> before submit</div>')
+      })
+      .on('Romo.Form:afterSubmit', function(e, romoForm) {
+        statusDOM.appendHTML('<div>-> after submit</div>')
+      })
+      .on('Romo.Form:confirmSubmit', function(e, romoForm) {
+        statusDOM.appendHTML('<div>-> confirm submit</div>')
+      })
+      .on('Romo.Form:browserSubmit', function(e, romoForm) {
+        statusDOM.appendHTML('<div>-> browser submit</div>')
+      })
+      .on('Romo.Form:xhrSubmit', function(e, romoForm, xhrOptions) {
+        statusDOM.appendHTML('<div>-> XHR submit</div>')
+        statusDOM.appendHTML(`<code>${JSON.stringify(xhrOptions)}</code>`)
+        console.log('-> XHR submit, xhrOptions:')
+        console.log(xhrOptions)
+      })
+      .on('Romo.Form:eventSubmit', function(e, romoForm, formValues) {
+        statusDOM.appendHTML('<div>-> event submit, formValues:</div>')
+        statusDOM.appendHTML(`<code>${JSON.stringify(formValues)}</code>`)
+        console.log('-> event submit, formValues:')
+        console.log(formValues)
+      })
+      .on('Romo.Form:submitSuccess', function(e, romoForm, data, xhr) {
+        statusDOM.appendHTML('<div>-> success</div>')
+        statusDOM.appendHTML(`<code>${JSON.stringify(data)}</code>`)
+        console.log('-> success, data:')
+        console.log(data)
+      })
+      .on('Romo.Form:submitError', function(e, romoForm, data, xhr) {
+        statusDOM.appendHTML('<div>-> error</div>')
+        statusDOM.appendHTML(`<code>${JSON.stringify(data)}</code>`)
+        console.log('-> error, data:')
+        console.log(data)
+      })
+      .on('Romo.Form:submitComplete', function(e, romoForm) {
+        statusDOM.appendHTML('<div>-> complete</div>')
+        romoForm.doStopSubmitSpinners()
+      })
+  })
+</script>

--- a/test/dom_components/form_tests.html
+++ b/test/dom_components/form_tests.html
@@ -14,10 +14,23 @@
         data-xhr-get-json-form
         data-romo-form
         data-romo-form-disable-focus-on-init="true">
-    <input type="text" name="value"
+    <input type="text" name="value" value="thing / something"
            placeholder="Enter a value.">
     <button type="submit"
-            data-romo-spinner>Submit</button>
+            data-romo-spinner>Submit (redirects page by default)</button>
+  </form>
+
+  <form action="https://api.github.com/repos/redding/romo-js"
+        method="get"
+        accept-charset="UTF-8"
+        data-xhr-get-json-form
+        data-romo-form
+        data-romo-form-redirect-page="false"
+        data-romo-form-disable-focus-on-init="true">
+    <input type="text" name="value" value="thing / something"
+           placeholder="Enter a value.">
+    <button type="submit"
+            data-romo-spinner>Submit (no redirect page)</button>
   </form>
 
   <div data-form-status>

--- a/test/system_tests.html
+++ b/test/system_tests.html
@@ -19,6 +19,7 @@
   <div data-test-component-pages>
     <h3>DOM Components</h3>
     <ul>
+      <li><a href="./dom_components/form_tests.html">Romo.Form</a></li>
       <li><a href="./dom_components/spinner_tests.html">Romo.Spinner</a></li>
       <li><a href="./dom_components/xhr_tests.html">Romo.XHR</a></li>
     </ul>


### PR DESCRIPTION
This component binds to form elements and layers in form submission
behaviors. Configure using DOM data attributes and interact with
DOM events.

This component supports the following submission methods:
* "browser submit" - use the native browser
* "XHR submit" (this is the default submission type)
  * emits XHR lifecycle events similar to Romo.XHR
* "event submit" - emits an event with form values in the payload
  but doesn't actually submit the form

### update Romo.Form XHR GET submits to redirect the page by default

Also, decode param values and remove blank param values by
default. This is useful for "search forms" which is the most
common use of an XHR form doing a GET request.

### rework Romo.DOM enumerator methods to emit DOM objects by default

This switches the default Array/Enumerator type methods to emit
Romo.DOM instances instead of the raw Elements by default. This
follows the principle of least surprise in that if you are
operating on DOM, you expect to get DOM instance to operate on.

This also adds *Element equivalent methods that continue emitting
Elements and backports the existing usages to call those since they
were already expecting/operating on Elements.

![image2he84](https://user-images.githubusercontent.com/82110/102923915-33b04b80-4456-11eb-9226-5fdb078c64fe.jpg)
