### PR TITLE
add Romo.UI.Nav

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -1,0 +1,4 @@
+import './env.js'
+import './api.js'
+import './utilities.js'
+import './components.js'

--- a/lib/romo-ui.js
+++ b/lib/romo-ui.js
@@ -1,0 +1,4 @@
+import './core.js'
+import './ui.js'
+
+Romo.setup()

--- a/lib/romo.js
+++ b/lib/romo.js
@@ -1,6 +1,3 @@
-import './env.js'
-import './api.js'
-import './utilities.js'
-import './components.js'
+import './core.js'
 
 Romo.setup()

--- a/lib/ui.js
+++ b/lib/ui.js
@@ -1,0 +1,1 @@
+import './ui/nav.js'

--- a/lib/ui/nav.js
+++ b/lib/ui/nav.js
@@ -1,0 +1,45 @@
+import './nav/link.js'
+
+// Romo.UI.Nav is used to auto-activate nav links in nav components. This removes the
+// need to view model which nav link is currently active. This also allows for
+// easier caching of markup as you don't need to cache for each permutation of
+// active nav links.
+Romo.define('Romo.UI.Nav', function() {
+  return class extends Romo.DOMComponent {
+    constructor(dom) {
+      super(dom)
+
+      this._bind()
+    }
+
+    get activeCSSClass() {
+      return this.dom.data('romo-ui-nav-active-css-class') || 'active'
+    }
+
+    get linksDOM() {
+      return this.dom.find('[data-romo-ui-nav-link]')
+    }
+
+    doRefresh() {
+      const activeCSSClass = this.activeCSSClass
+
+      this.linksDOM.forEach(function(linkDOM) {
+        new Romo.UI.Nav.Link(linkDOM, { activeCSSClass: activeCSSClass })
+      })
+
+      return this
+    }
+
+    // private
+
+    _bind() {
+      this.dom.on('Romo.UI.Nav:triggerRefresh', Romo.bind(function(e) {
+        this.doRefresh()
+      }, this))
+
+      this.doRefresh()
+    }
+  }
+})
+
+Romo.addAutoInitSelector('[data-romo-ui-nav]', Romo.UI.Nav)

--- a/lib/ui/nav/link.js
+++ b/lib/ui/nav/link.js
@@ -1,0 +1,30 @@
+Romo.define('Romo.UI.Nav.Link', function() {
+  return class extends Romo.DOMComponent {
+    constructor(dom, { activeCSSClass } = {}) {
+      super(dom)
+      this.activeCSSClass = activeCSSClass
+
+      this._bind()
+    }
+
+    get url() {
+      return this.dom.data('romo-ui-nav-link-url') || this.dom.attr('href')
+    }
+
+    /* Private */
+
+    _bind() {
+      if (this.url === this._currentURL) {
+        this.dom.setData('romo-ui-nav-link-active', true)
+        this.dom.addClass(this.activeCSSClass)
+      } else {
+        this.dom.setData('romo-ui-nav-link-active', false)
+        this.dom.removeClass(this.activeCSSClass)
+      }
+    }
+
+    get _currentURL() {
+      return window.location.pathname
+    }
+  }
+})

--- a/lib/utilities/dom.js
+++ b/lib/utilities/dom.js
@@ -166,6 +166,10 @@ Romo.define('Romo.DOM', function() {
       return Romo.dom(Romo.rmClass(this, className))
     }
 
+    removeClass(className) {
+      return this.rmClass(className)
+    }
+
     toggleClass(className) {
       return Romo.dom(Romo.toggleClass(this, className))
     }

--- a/test/system_tests.html
+++ b/test/system_tests.html
@@ -24,6 +24,10 @@
       <li><a href="./dom_components/spinner_tests.html">Romo.Spinner</a></li>
       <li><a href="./dom_components/xhr_tests.html">Romo.XHR</a></li>
     </ul>
+    <h3>UI Components</h3>
+    <ul>
+      <li><a href="./ui/nav_tests.html">Romo.UI.Nav</a></li>
+    </ul>
   </div>
   <div data-test-output></div>
   <div data-test-support>

--- a/test/ui/nav_tests.html
+++ b/test/ui/nav_tests.html
@@ -1,0 +1,42 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="/support/romo-js/romo.css"/>
+  <style>
+  </style>
+</head>
+<body>
+  <h1>Romo.UI.Nav system tests</h1>
+  <h3>Basic with defaults</h3>
+  <ul data-romo-ui-nav>
+    <li>
+      <a href="/ui/nav_tests.html"
+         data-romo-ui-nav-link>Nav Tests</a>
+    </li>
+    <li>
+      <a href="/some-other-page"
+         data-romo-ui-nav-link>Some Other Page</a>
+    </li>
+  </ul>
+  <h3>With customizations</h3>
+  <ul data-romo-ui-nav
+      data-romo-ui-nav-active-css-class="active-link-li">
+    <li data-romo-ui-nav-link
+        data-romo-ui-nav-link-url="/ui/nav_tests.html">
+      <a href="/ui/nav_tests.html">Nav Tests</a>
+    </li>
+    <li data-romo-ui-nav-link
+        data-romo-ui-nav-link-url="/some-other-page">
+      <a href="/some-other-page">Some Other Page</a>
+    </li>
+  </ul>
+</body>
+<script type="module" src="/support/romo-js/romo-ui.js"></script>
+<script type="module" src="/support/tests.js"></script>
+<script type="module">
+  Romo.onReady(function() {
+    const lastDOM = Romo.f('[data-romo-ui-nav]').last
+    lastDOM.setData('romo-ui-nav-active-css-class', 'active-link-li-alt')
+    lastDOM.trigger('Romo.UI.Nav:triggerRefresh')
+  })
+</script>


### PR DESCRIPTION
This is a component for detecting and setting active nav links
using JS. In the future, other nav-specific utilities may be
added.

# Other Changes

### move all core imports into a dedicated file

This is prep for moding how much of RomoJS to import b/c I'll be
adding a UI module that loads a bunch of extra UI-specific
components that aren't always needed/desired. Whether you load
the UI-variant or not, you always need to import the core
logic/components.

### add a romo-ui.js variant

This variant will load all of the core romo components and
utilities but will also load in all of the UI components that
Romo offers.

### alias Romo.DOM#rmclass as Romo.DOM#removeClass

This version may be more intuitive/desirable to use. Also this
is more compatible with jQuery's API.

# Demo

![romo-ui-nav](https://user-images.githubusercontent.com/82110/104619452-7deeac00-5653-11eb-9e4d-7d2b32f3b4b7.jpg)

