### PR TITLE
add separate and additional publish for Romo UI

### DIFF
--- a/bin/publish
+++ b/bin/publish
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+npm publish --access public

--- a/bin/publish_for_ui
+++ b/bin/publish_for_ui
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cp package_for_ui.json package.json
+./bin/publish
+git k package.json

--- a/bin/release
+++ b/bin/release
@@ -1,2 +1,3 @@
 #!/bin/bash
-./bin/lint && ./bin/tag && git push --tags && npm publish --access public
+
+./bin/lint && ./bin/tag && git push && git push --tags && ./bin/publish && ./bin/publish_for_ui

--- a/package_for_ui.json
+++ b/package_for_ui.json
@@ -1,0 +1,35 @@
+{
+  "name": "@reddingjs/romo-ui",
+  "version": "0.1.0-rc5",
+  "description": "A JS UI toolkit build on @reddingjs/romo-js.",
+  "main": "lib/romo-ui.js",
+  "dependencies": {
+  },
+  "devDependencies": {
+    "eslint": "^6.8.0",
+    "eslint-config-standard": "^14.1.0",
+    "eslint-plugin-import": "^2.18.2",
+    "eslint-plugin-node": "^10.0.0",
+    "eslint-plugin-promise": "^4.0.1",
+    "eslint-plugin-standard": "^4.0.1",
+    "esmify": "^2.1.1",
+    "standard": "^16.0.3"
+  },
+  "scripts": {
+    "lint": "./bin/lint",
+    "refresh": "./bin/cp-source-for-tests",
+    "test": "./bin/test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/redding/romo-js.git"
+  },
+  "keywords": [
+    "JS",
+    "Utilities"
+  ],
+  "author": "Kelly Redding & Collin Redding",
+  "license": "MIT",
+  "homepage": "https://github.com/redding/romo-js#readme",
+  "bugs": "https://github.com/redding/romo-js/issues"
+}


### PR DESCRIPTION
Having a separate package makes it nice for explicitly choosing
whether to bring in the UI extras or not. This enables using
e.g. Skypack.dev. However I didn't want the overhead of having
two distinct repos when one hard-depends on another. I also
wasn't wild about versioning them independently b/c confusion.

This adds an additional package.json and package for Romo UI and
then creates a publish bin for hijacking the default publish
using the UI's package JSON. This allows me to develop, version,
and release the packages in sync and ensures that changes from
one package don't break another.

Note: I maybe could have done this by using a monorepo type
pattern but this was easier to proof-of-concept. I may move
to a monorepo in the future when things stabalize - not sure.


# Demo

Romo JS package:
https://www.npmjs.com/package/@reddingjs/romo-js

Romo UI package:
https://www.npmjs.com/package/@reddingjs/romo-ui
