### PR TITLE
extract Romo.config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,7 +13,9 @@
   "globals": {
     // Please keep this list alphabetized.
     "$": false,
-    "Romo": false
+    "Romo": false,
+    "RomoConfig": false,
+    "RomoEnv": false
   },
 
   // These are overrides to StandardJS rules.

--- a/lib/api/page.js
+++ b/lib/api/page.js
@@ -9,45 +9,20 @@ Romo.redirectPage =
   }
 
 Romo.alert =
-  function(alertMessage, { debugMessage, callbackFn } = {}) {
-    Romo.showAlert(alertMessage, debugMessage)
-
-    if (callbackFn) {
-      callbackFn()
-    }
+  function(alertMessage, { debugMessage } = {}) {
+    Romo.config.alert.showAlertFn(alertMessage, {
+      debugMessage: debugMessage,
+    })
   }
 
 Romo.alertAndReloadPage =
-  function(alertMessage, { debugMessages } = {}) {
-    Romo.alert(
-      alertMessage,
-      {
-        debugMessages: debugMessages,
-        callbackFn:    function() { Romo.reloadPage() },
-      },
-    )
+  function(alertMessage, { debugMessage } = {}) {
+    Romo.config.alert.showAlertAndReloadPageFn(alertMessage, {
+      debugMessage: debugMessage,
+    })
   }
 
-// Override as desired.
-Romo.showAlert =
-  function(alertMessage, debugMessage) {
-    if (alertMessage.length !== 0) {
-      var message = alertMessage
-
-      if (debugMessage) {
-        message += `:\n${debugMessage}`
-      }
-      console.error(message)
-    }
-  }
-
-// Override as desired.
 Romo.showFlashAlerts =
   function(romoFlashAlerts) {
-    Romo.alert(
-      Romo
-        .array(romoFlashAlerts)
-        .map(function(romoFlashAlert) { return romoFlashAlert.toString() })
-        .join('\n')
-    )
+    Romo.config.alert.showFlashAlertsFn(romoFlashAlerts)
   }

--- a/lib/api/xhr.js
+++ b/lib/api/xhr.js
@@ -7,9 +7,3 @@ Romo.urlSearch =
   function(...args) {
     return new Romo.URLSearchParams(...args).toString()
   }
-
-// Override as desired.
-Romo.xhrErrorAlertMessage =
-  function() {
-    return 'An error has occurred.'
-  }

--- a/lib/components/form.js
+++ b/lib/components/form.js
@@ -24,12 +24,12 @@ Romo.define('Romo.Form', function() {
       Romo.pushFn(Romo.bind(this._bind, this))
     }
 
-    static doTriggerAddValidationMessages(formDOM, messages) {
-      formDOM.trigger('Romo.Form:triggerAddValidationMessages', [messages])
+    static doAddValidationErrorMessages(formDOM, messages) {
+      Romo.config.form.addValidationErrorMessagesFn(formDOM, messages)
     }
 
-    static doTriggerRemoveValidationMessages(formDOM) {
-      formDOM.trigger('Romo.Form:triggerRemoveErrorMessages')
+    static doRemoveValidationErrorMessages(formDOM) {
+      Romo.config.form.removeValidationErrorMessagesFn(formDOM)
     }
 
     get submission() {
@@ -141,7 +141,7 @@ Romo.define('Romo.Form', function() {
 
       this._bindForm()
 
-      this.class.doTriggerRemoveValidationMessages(this.dom)
+      this.class.doRemoveValidationErrorMessages(this.dom)
       this.doFocusFirstVisibleInput()
     }
 

--- a/lib/components/form/base_xhr_submission.js
+++ b/lib/components/form/base_xhr_submission.js
@@ -26,13 +26,14 @@ Romo.define('Romo.Form.BaseXHRSubmission', function() {
 
     doStartSubmit(submitXHROptions) {
       const requiredXHROptions = {
-        url:          this.callURL,
-        method:       this.callMethod,
-        responseType: this.responseType,
-        reloadPageOn: this.reloadPageOn,
-        onSuccess:    Romo.bind(this._onSuccess, this),
-        onError:      Romo.bind(this._onError, this),
-        onCallEnd:    Romo.bind(this._onCallEnd, this),
+        url:                   this.callURL,
+        method:                this.callMethod,
+        responseType:          this.responseType,
+        reloadPageOn:          this.reloadPageOn,
+        onSuccess:             Romo.bind(this._onSuccess, this),
+        onError:               Romo.bind(this._onError, this),
+        onCallEnd:             Romo.bind(this._onCallEnd, this),
+        mutedErrorStatusCodes: [422],
       }
 
       return super.doStartSubmit(function() {

--- a/lib/components/form/base_xhr_submission.js
+++ b/lib/components/form/base_xhr_submission.js
@@ -52,16 +52,16 @@ Romo.define('Romo.Form.BaseXHRSubmission', function() {
     // private
 
     _onSuccess(response, status, xhr) {
-      Romo.Form.doTriggerRemoveValidationMessages(this.formDOM)
+      Romo.Form.doRemoveValidationErrorMessages(this.formDOM)
 
       this.formDOM.trigger('Romo.Form.Submission:submitSuccess', [response, xhr])
     }
 
     _onError(response, status, xhr) {
-      Romo.Form.doTriggerRemoveValidationMessages(this.formDOM)
+      Romo.Form.doRemoveValidationErrorMessages(this.formDOM)
 
       if (xhr.status === 422 && xhr.responseJSON) {
-        Romo.Form.doTriggerAddValidationMessages(this.formDOM, xhr.responseJSON)
+        Romo.Form.doAddValidationErrorMessages(this.formDOM, xhr.responseJSON)
       }
 
       this.formDOM.trigger('Romo.Form.Submission:submitError', [response, xhr])

--- a/lib/components/xhr.js
+++ b/lib/components/xhr.js
@@ -223,8 +223,8 @@ Romo.define('Romo.XHR', function() {
       e.stopPropagation()
 
       if (this.dom.hasClass('disabled') === false) {
-        // Make the call late-bound to let all callOn event type handling finish
-        // before making the call.
+        // Make the call late-bound to let all `callOn`` event type handling
+        // finish before making the call.
         Romo.pushFn(Romo.bind(this.doCall, this))
       }
     }

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,0 +1,90 @@
+if (window.Romo === undefined) {
+  window.Romo = {}
+}
+
+// A generic class to centralize global Romo configurtion and allow for easily
+// overriding and extending the configurtion seettings. All values are called
+// "just in time"; they can be overridden at any time and will immediately take
+// effect.
+//
+// Extend the configuration API with e.g.:
+//   Romo.config.my_api = new RomoConfig()
+//   Romo.config.my_api.value = 'some value'
+class RomoConfig {}
+Romo.config = new RomoConfig()
+Romo.config.alert = new RomoConfig()
+Romo.config.form = new RomoConfig()
+Romo.config.xhr = new RomoConfig()
+
+// Default configuration; override as needed/desired.
+
+// Alert
+
+Romo.config.alert.showAlertFn =
+  function(alertMessage, { debugMessage } = {}) {
+    if (alertMessage && alertMessage.length !== 0) {
+      var message = alertMessage
+
+      if (debugMessage && debugMessage.length !== 0) {
+        message += `:\n${debugMessage}`
+      }
+      console.error(message)
+    }
+  }
+
+Romo.config.alert.showAlertAndReloadPageFn =
+  function(alertMessage, { debugMessage } = {}) {
+    Romo.config.alert.showAlertFn(alertMessage, { debugMessage: debugMessage })
+    Romo.reloadPage()
+  }
+
+Romo.config.alert.showFlashAlertsFn =
+  function(romoFlashAlerts) {
+    Romo.alert(
+      Romo
+        .array(romoFlashAlerts)
+        .map(function(romoFlashAlert) { return romoFlashAlert.toString() })
+        .join('\n')
+    )
+  }
+
+// Form
+
+Romo.config.form.addValidationErrorMessagesFn =
+  function(formDOM, messages) {
+    console.error(
+      'NotImplementedError: override ' +
+      'Romo.config.form.addValidationErrorMessagesFn with a custom ' +
+      'function that adds validation error messages to form input markup.'
+    )
+  }
+
+Romo.config.form.removeValidationErrorMessagesFn =
+  function(formDOM) {
+    console.error(
+      'NotImplementedError: override ' +
+      'Romo.config.form.removeValidationErrorMessagesFn with a custom ' +
+      'function that removes validation error messages from form input markup.'
+    )
+  }
+
+// XHR
+
+Romo.config.xhr.isSuccessStatusCode =
+  function(statusCode) {
+    return (statusCode >= 200 && statusCode < 300) || statusCode === 304
+  }
+
+Romo.config.xhr.showErrorAlertFn =
+  function(romoXMLHttpRequest, { debugMessage } = {}) {
+    Romo.alert('An error occurred.', { debugMessage: debugMessage })
+  }
+
+Romo.config.xhr.showErrorAlertAndReloadPageFn =
+  function(romoXMLHttpRequest, { debugMessage } = {}) {
+    Romo.config.xhr.showErrorAlertFn(
+      romoXMLHttpRequest,
+      { debugMessage: debugMessage },
+    )
+    Romo.reloadPage()
+  }

--- a/lib/core.js
+++ b/lib/core.js
@@ -1,3 +1,4 @@
+import './config.js'
 import './env.js'
 import './api.js'
 import './utilities.js'

--- a/lib/utilities/xml_http_request.js
+++ b/lib/utilities/xml_http_request.js
@@ -92,10 +92,6 @@ Romo.define('Romo.XMLHttpRequest', function() {
       return true
     }
 
-    static successStatusCode(statusCode) {
-      return (statusCode >= 200 && statusCode < 300) || statusCode === 304
-    }
-
     get isNonTextResponseType() {
       return (
         this.responseType === this.class.ARRAYBUFFER ||
@@ -188,7 +184,7 @@ Romo.define('Romo.XMLHttpRequest', function() {
     _onLoad() {
       this._showFlashAlerts()
 
-      if (this.class.successStatusCode(this.xhr.status)) {
+      if (Romo.config.xhr.isSuccessStatusCode(this.xhr.status)) {
         if (this.onSuccess) {
           if (this.isNonTextResponseType) {
             this.onSuccess(this.xhr.response, this.xhr.status, this.xhr)
@@ -248,13 +244,13 @@ Romo.define('Romo.XMLHttpRequest', function() {
           this.reloadPageOn === this.class.COMPLETE ||
             this.reloadPageOn === this.class.ERROR
         ) {
-          Romo.alertAndReloadPage(
-            Romo.xhrErrorAlertMessage(),
+          Romo.config.xhr.showErrorAlertAndReloadPageFn(
+            this,
             { debugMessage: this.errorResponseText },
           )
         } else {
-          Romo.alert(
-            Romo.xhrErrorAlertMessage(),
+          Romo.config.xhr.showErrorAlertFn(
+            this,
             { debugMessage: this.errorResponseText },
           )
         }

--- a/lib/utilities/xml_http_request.js
+++ b/lib/utilities/xml_http_request.js
@@ -17,6 +17,7 @@ Romo.define('Romo.XMLHttpRequest', function() {
       responseType,
       username,
       password,
+      mutedErrorStatusCodes,
     } = {}) {
       if (url.toString().trim() === '') {
         throw new Error('Romo.XMLHttpRequest: no URL given.')
@@ -38,6 +39,7 @@ Romo.define('Romo.XMLHttpRequest', function() {
       this.responseType = responseType
       this.username = username
       this.password = password
+      this.mutedErrorStatusCodes = Romo.array(mutedErrorStatusCodes)
 
       this.errorResponseText = undefined
     }
@@ -203,12 +205,14 @@ Romo.define('Romo.XMLHttpRequest', function() {
       const response =
         this.isNonTextResponseType ? this.xhr.response : this.xhr.responseText
 
-      if (this.isBinaryResponseType) {
-        this.errorResponseText = `${this.xhr.status} ${this.xhr.statusText}`
-      } else if (this.responseType === this.class.JSON) {
-        this.errorResponseText = JSON.stringify(response)
-      } else {
-        this.errorResponseText = response.toString()
+      if (!this.mutedErrorStatusCodes.includes(this.xhr.status)) {
+        if (this.isBinaryResponseType) {
+          this.errorResponseText = `${this.xhr.status} ${this.xhr.statusText}`
+        } else if (this.responseType === this.class.JSON) {
+          this.errorResponseText = JSON.stringify(response)
+        } else {
+          this.errorResponseText = response.toString()
+        }
       }
 
       if (this.onError) {

--- a/test/system_tests.html
+++ b/test/system_tests.html
@@ -951,26 +951,6 @@
         test.unstubConsoleError()
       })
 
-      tests.test('<code>Romo.alert</code> given callbackFn', function(test) {
-        test.stubConsoleError()
-
-        // Expect the callbackFn to do assertions to make the test pass.
-        test.fail()
-
-        Romo.alert(
-          'test alert message',
-          {
-            callbackFn:
-              function() {
-                test.assert(console.errorMessages.length === 1)
-                test.assert(console.errorMessages[0][0] === 'test alert message')
-              }
-          }
-        )
-
-        test.unstubConsoleError()
-      })
-
       tests.test('<code>Romo.alertAndReloadPage</code>', function(test) {
         test.assert(typeof Romo.alertAndReloadPage === 'function')
       })


### PR DESCRIPTION
This sets up a Romo.config object and extracts all of the hooks
that could require custom configuration as functions on the
object.

This allows users to override these functions to hook in their
own custom logic. Right now this includes hooks for alerting
users, handling form validation error messages, and interpreting
XHR status codes. This config can also be extended to add custom
namespaces and functions.

# Other Changes

### add XMLHttpRequest muted error status codes; use in XHR form submissions

This allows XHR forms to mute error messages due to 422 error
statuses as they manually handle these by adding validation error
messages. Therefore there is no reason to alert the user so they
get muted.
