### PR TITLE
add Romo.UI.Frame component

### DIFF
--- a/lib/components/form/base_xhr_submission.js
+++ b/lib/components/form/base_xhr_submission.js
@@ -15,8 +15,7 @@ Romo.define('Romo.Form.BaseXHRSubmission', function() {
 
     get responseType() {
       return (
-        this.formDOM.data('romo-form-xhr-response-type') ||
-          Romo.XMLHttpRequest.JSON
+        this.formDOM.data('romo-form-xhr-response-type')
       )
     }
 
@@ -25,16 +24,17 @@ Romo.define('Romo.Form.BaseXHRSubmission', function() {
     }
 
     doStartSubmit(submitXHROptions) {
-      const requiredXHROptions = {
-        url:                   this.callURL,
-        method:                this.callMethod,
-        responseType:          this.responseType,
-        reloadPageOn:          this.reloadPageOn,
-        onSuccess:             Romo.bind(this._onSuccess, this),
-        onError:               Romo.bind(this._onError, this),
-        onCallEnd:             Romo.bind(this._onCallEnd, this),
-        mutedErrorStatusCodes: [422],
-      }
+      const requiredXHROptions =
+        {
+          url:                   this.callURL,
+          method:                this.callMethod,
+          responseType:          this.responseType,
+          reloadPageOn:          this.reloadPageOn,
+          onSuccess:             Romo.bind(this._onSuccess, this),
+          onError:               Romo.bind(this._onError, this),
+          onCallEnd:             Romo.bind(this._onCallEnd, this),
+          mutedErrorStatusCodes: [422],
+        }
 
       return super.doStartSubmit(function() {
         try {

--- a/lib/components/form/xhr_get_submission.js
+++ b/lib/components/form/xhr_get_submission.js
@@ -8,7 +8,7 @@ import './values.js'
 Romo.define('Romo.Form.XHRGetSubmission', function() {
   return class extends Romo.Form.BaseXHRSubmission {
     get redirectPage() {
-      return this.formDOM.data('romo-form-redirect-page') !== false
+      return this.formDOM.data('romo-form-redirect-page') === true
     }
 
     get removeBlankGetParams() {

--- a/lib/components/spinner.js
+++ b/lib/components/spinner.js
@@ -54,13 +54,13 @@ Romo.define('Romo.Spinner', function() {
       })
     }
 
-    doStart(customBasisSizePx) {
+    doStart({ sizePx, startImmediately } = {}) {
       if (this.spinner || this.isDisabled) {
         return
       }
 
       var basisSizePx = (
-        customBasisSizePx ||
+        sizePx ||
         this.sizePx ||
         Math.min(Romo.width(this.containerDOM), Romo.height(this.containerDOM))
       )

--- a/lib/components/spinner.js
+++ b/lib/components/spinner.js
@@ -12,8 +12,8 @@ Romo.define('Romo.Spinner', function() {
     constructor(dom) {
       super(dom)
 
-      this.dom.on('Romo.Spinner:triggerStart', Romo.bind(function(e, basisSizePxPx) {
-        this.doStart(basisSizePxPx)
+      this.dom.on('Romo.Spinner:triggerStart', Romo.bind(function(e, basisSizePx) {
+        this.doStart({ sizePx: basisSizePx })
       }, this))
       this.dom.on('Romo.Spinner:triggerStop', Romo.bind(function(e) {
         this.doStop()
@@ -91,58 +91,76 @@ Romo.define('Romo.Spinner', function() {
       this.containerHTML = this.containerDOM.innerHTML
       this.containerStyle = this.containerDOM.attr('style')
 
-      Romo.pushFn(Romo.bind(function() {
-        this.containerDOM
-          .batchSetStyle({
-            position:        'relative',
-            width:           Romo.width(this.containerDOM) + 'px',
-            height:          Romo.height(this.containerDOM) + 'px',
-            color:           this.containerDOM.css('color'),
-            backgroundColor: this.containerDOM.css('background-color'),
-            borderColor:     this.containerDOM.css('border-color'),
-          })
-          .clearHTML()
-
-        if (this.spinner) {
-          this.spinner.spin(this.containerDOM.firstElement)
-        }
-
-        this.dom.trigger('Romo.Spinner:started', [this])
-      }, this))
+      if (startImmediately) {
+        this._startSpinner()
+      } else {
+        Romo.pushFn(Romo.bind(function() {
+          this._startSpinner()
+        }, this))
+      }
 
       return this
     }
 
-    doStop() {
-      Romo.pushFn(Romo.bind(function() {
-        if (this.spinner === undefined) {
-          return
-        }
-
-        this.spinner.stop()
-        this.spinner = undefined
-
-        if (this.containerHTML) {
-          this.containerDOM.innerHTML = this.containerHTML
-        }
-
-        this.containerDOM.batchSetStyle({
-          position:        '',
-          width:           '',
-          height:          '',
-          color:           '',
-          backgroundColor: '',
-          borderColor:     '',
-        })
-
-        if (this.containerStyle) {
-          this.containerDOM.setAttr('style', this.containerStyle)
-        }
-
-        this.dom.trigger('Romo.Spinner:stopped', [this])
-      }, this))
+    doStop({ stopImmediately } = {}) {
+      if (stopImmediately) {
+        this._stopSpinner()
+      } else {
+        Romo.pushFn(Romo.bind(function() {
+          this._stopSpinner()
+        }, this))
+      }
 
       return this
+    }
+
+    // private
+
+    _startSpinner() {
+      this.containerDOM
+        .batchSetStyle({
+          position:        'relative',
+          width:           Romo.width(this.containerDOM) + 'px',
+          height:          Romo.height(this.containerDOM) + 'px',
+          color:           this.containerDOM.css('color'),
+          backgroundColor: this.containerDOM.css('background-color'),
+          borderColor:     this.containerDOM.css('border-color'),
+        })
+        .clearHTML()
+
+      if (this.spinner) {
+        this.spinner.spin(this.containerDOM.firstElement)
+      }
+
+      this.dom.trigger('Romo.Spinner:started', [this])
+    }
+
+    _stopSpinner() {
+      if (this.spinner === undefined) {
+        return
+      }
+
+      this.spinner.stop()
+      this.spinner = undefined
+
+      if (this.containerHTML) {
+        this.containerDOM.innerHTML = this.containerHTML
+      }
+
+      this.containerDOM.batchSetStyle({
+        position:        '',
+        width:           '',
+        height:          '',
+        color:           '',
+        backgroundColor: '',
+        borderColor:     '',
+      })
+
+      if (this.containerStyle) {
+        this.containerDOM.setAttr('style', this.containerStyle)
+      }
+
+      this.dom.trigger('Romo.Spinner:stopped', [this])
     }
   }
 })

--- a/lib/components/xhr.js
+++ b/lib/components/xhr.js
@@ -218,7 +218,6 @@ Romo.define('Romo.XHR', function() {
 
     _onCallOn(e) {
       e.preventDefault()
-      e.stopPropagation()
 
       if (this.dom.hasClass('disabled') === false) {
         // Make the call late-bound to let all `callOn`` event type handling

--- a/lib/config.js
+++ b/lib/config.js
@@ -14,6 +14,7 @@ class RomoConfig {}
 Romo.config = new RomoConfig()
 Romo.config.alert = new RomoConfig()
 Romo.config.form = new RomoConfig()
+Romo.config.frames = new RomoConfig()
 Romo.config.popovers = new RomoConfig()
 Romo.config.xhr = new RomoConfig()
 
@@ -67,6 +68,13 @@ Romo.config.form.removeErrorMessagesFn =
       'Romo.config.form.removeErrorMessagesFn with a custom ' +
       'function that removes validation error messages from form input markup.'
     )
+  }
+
+// Frames
+
+Romo.config.frames.defaultSpinnerHeightPxFn =
+  function(frameDOM) {
+    return 45
   }
 
 // Popovers

--- a/lib/ui/components.js
+++ b/lib/ui/components.js
@@ -1,5 +1,6 @@
 import './components/dropdown.js'
 import './components/dropdown_form.js'
+import './components/frame.js'
 import './components/modal.js'
 import './components/modal_form.js'
 import './components/nav.js'

--- a/lib/ui/components/frame.js
+++ b/lib/ui/components/frame.js
@@ -1,0 +1,242 @@
+Romo.define('Romo.UI.Frame', function() {
+  return class extends Romo.DOMComponent {
+    constructor(dom) {
+      super(dom)
+
+      this._contentStack = []
+      this._bind()
+    }
+
+    get contentStackSize() {
+      return this._contentStack.length
+    }
+
+    get isContentStackEmpty() {
+      return this.contentStackSize === 0
+    }
+
+    doPushContent(contentHTMLOrJSON) {
+      this._pushContent()
+      const contentHTML = this._updateContent(contentHTMLOrJSON)
+      this.dom.trigger('Romo.UI.Frame:contentPushed', [this, contentHTML])
+
+      return this
+    }
+
+    doPopContent() {
+      if (!this.isContentStackEmpty) {
+        const contentHTML = this._contentStack.pop()
+        this._updateContent(contentHTML)
+        this.dom.trigger('Romo.UI.Frame:contentPopped', [this])
+      }
+
+      return this
+    }
+
+    doClearContentStack() {
+      this._contentStack = []
+      this.dom.trigger('Romo.UI.Frame:contentStackCleared', [this])
+
+      return this
+    }
+
+    doStartSpinner() {
+      this.romoSpinner.doStart({ startImmediately: true })
+
+      return this
+    }
+
+    doStopSpinner() {
+      this.romoSpinner.doStop({ stopImmediately: true })
+
+      return this
+    }
+
+    // private
+
+    _bind() {
+      this._bindSpinner()
+
+      this.dom.on(
+        'Romo.UI.Frame:triggerPushContent',
+        Romo.bind(function(e, contentHTMLOrJSON) {
+          this.doPushContent(contentHTMLOrJSON)
+        }, this)
+      )
+      this.dom.on('Romo.UI.Frame:triggerPopContent', Romo.bind(function() {
+        this.doPopContent()
+      }, this))
+
+      this._bindContent()
+    }
+
+    _bindSpinner() {
+      this.dom.setDataDefault(
+        'romo-spinner-size-px',
+        Romo.config.frames.defaultSpinnerHeightPxFn(this.dom)
+      )
+
+      this.dom.on('Romo.UI.Frame:triggerSpinnerStart', Romo.bind(function() {
+        this.doStartSpinner()
+      }, this))
+      this.dom.on('Romo.UI.Frame:triggerSpinnerStop', Romo.bind(function() {
+        this.doStopSpinner()
+      }, this))
+
+      this.romoSpinner = new Romo.Spinner(this.dom)
+    }
+
+    _bindContent() {
+      this._bindPops()
+      this._bindXHRs()
+      this._bindForm()
+    }
+
+    _bindPops() {
+      this.dom.find('[data-romo-ui-frame-pop]').on(
+        'click',
+        Romo.bind(function(e) {
+          e.preventDefault()
+          this.doPopContent()
+        }, this)
+      )
+    }
+
+    _bindXHRs() {
+      const xhrDOMs = this.dom.find('[data-romo-ui-frame-xhr]')
+      xhrDOMs.forEach(function(xhrDOM) {
+        new Romo.XHR(xhrDOM)
+      })
+      xhrDOMs.on('Romo.XHR:callStart', Romo.bind(function(e, romoXHR) {
+        this.doStartSpinner()
+      }, this))
+      xhrDOMs.on('Romo.XHR:callEnd', Romo.bind(function(e, romoXHR) {
+        this.doStopSpinner()
+      }, this))
+      xhrDOMs.on(
+        'Romo.XHR:callSuccess',
+        Romo.bind(function(e, romoXHR, data, xhr) {
+          // Run in a pushFn to allow callEnd event to stop the spinner first.
+          Romo.pushFn(Romo.bind(function() {
+            this.doPushContent(data)
+          }, this))
+        }, this)
+      )
+    }
+
+    _bindForm() {
+      const formDOM = this.dom.find('[data-romo-ui-frame-form]')
+      var romoForm
+      const domSubmits = this.dom.find('[data-romo-form-submit]')
+      const domSubmitSpinners =
+        this.dom.find(
+          '[data-romo-form-submit][data-romo-spinner], ' +
+          '[data-romo-form-submit-spinner][data-romo-spinner]'
+        )
+
+      if (formDOM.length !== 0) {
+        romoForm =
+          new Romo.Form(
+            formDOM,
+            {
+              givenSubmits:        domSubmits,
+              givenSubmitSpinners: domSubmitSpinners,
+            }
+          )
+
+        this._proxyFormTriggeredEvents(
+          romoForm,
+          'triggerSubmit',
+          'triggerSubmitSpinnersStart',
+          'triggerSubmitSpinnersStop',
+          'triggerRemoveErrorMessages'
+        )
+        this._proxyFormEmittedEvents(
+          romoForm,
+          'beforeSubmit',
+          'afterSubmit',
+          'confirmSubmit',
+          'browserSubmit',
+          'xhrSubmit',
+          'eventSubmit',
+          'submitSuccess',
+          'submitError',
+          'submitComplete',
+          'errorMessagesAdded',
+          'errorMessagesRemoved',
+          'errorMessagesChanged'
+        )
+
+        formDOM.on(
+          'Romo.Form:submitSuccess',
+          Romo.bind(function(e, romoForm, data, xhr) {
+            this.doPushContent(data)
+          }, this)
+        )
+
+        // Delay so the form has time to bind first.
+        Romo.pushFn(Romo.bind(function() {
+          romoForm.doStopSubmitSpinners()
+        }, this))
+      }
+      // bind success to push content
+    }
+
+    _proxyFormTriggeredEvents(romoForm, ...eventNames) {
+      var formEventName, frameFormEventName
+
+      eventNames.forEach(Romo.bind(function(eventName) {
+        formEventName = `Romo.Form:${eventName}`
+        frameFormEventName = `Romo.UI.FrameForm:${eventName}`
+
+        Romo.proxyEvent({
+          fromElement:   this.dom,
+          toElement:     romoForm.dom,
+          fromEventName: frameFormEventName,
+          toEventName:   formEventName,
+          toArgs:        [],
+        })
+      }, this))
+    }
+
+    _proxyFormEmittedEvents(romoForm, ...eventNames) {
+      var formEventName, frameFormEventName
+
+      eventNames.forEach(Romo.bind(function(eventName) {
+        formEventName = `Romo.Form:${eventName}`
+        frameFormEventName = `Romo.UI.FrameForm:${eventName}`
+
+        Romo.proxyEvent({
+          fromElement:   romoForm.dom,
+          toElement:     this.dom,
+          fromEventName: formEventName,
+          toEventName:   frameFormEventName,
+          toArgs:        [this],
+        })
+      }, this))
+    }
+
+    _pushContent() {
+      this._contentStack.push(this.dom.innerHTML)
+    }
+
+    _updateContent(contentHTMLOrJSON) {
+      var contentHTML
+      if (typeof contentHTMLOrJSON === 'string') {
+        contentHTML = contentHTMLOrJSON
+      } else {
+        contentHTML = contentHTMLOrJSON.frameContentHTML
+      }
+
+      if (contentHTML) {
+        this.dom.updateHTML(contentHTML)
+        this._bindContent()
+      }
+
+      return contentHTML
+    }
+  }
+})
+
+Romo.addAutoInitSelector('[data-romo-ui-frame]', Romo.UI.Frame)
+Romo.addAutoInitSelector('romo-ui-frame', Romo.UI.Frame)

--- a/lib/ui/components/popover.js
+++ b/lib/ui/components/popover.js
@@ -386,8 +386,6 @@ Romo.define('Romo.UI.Popover', function() {
 
     _onPopoverCloseClick(e) {
       e.preventDefault()
-      e.stopPropagation()
-
       this.popoverOwner.doClosePopover()
     }
 

--- a/lib/ui/components/popover_form.js
+++ b/lib/ui/components/popover_form.js
@@ -123,18 +123,16 @@ Romo.define('Romo.UI.PopoverForm', function() {
     }
 
     _bindForm() {
-      const formDOM = this.popoverDOM.find('form[data-romo-popover-form]')
-      const initializedAttr = `${this.attrPrefix}-form-initialized`
-
-      var popoverDOMSubmits, popoverDOMSubmitSpinners
-      popoverDOMSubmits = this.popoverDOM.find('[data-romo-form-submit]')
-      popoverDOMSubmitSpinners =
+      const formDOM = this.popoverDOM.find('form[data-romo-ui-popover-form]')
+      const initializedDataAttr = `${this.attrPrefix}-form-initialized`
+      const popoverDOMSubmits = this.popoverDOM.find('[data-romo-form-submit]')
+      const popoverDOMSubmitSpinners =
         this.popoverDOM.find(
           '[data-romo-form-submit][data-romo-spinner], ' +
           '[data-romo-form-submit-spinner][data-romo-spinner]'
         )
 
-      if (formDOM.length !== 0 && formDOM.data(initializedAttr) !== true) {
+      if (formDOM.length !== 0 && formDOM.data(initializedDataAttr) !== true) {
         this.romoForm =
           new Romo.Form(
             formDOM,
@@ -143,7 +141,7 @@ Romo.define('Romo.UI.PopoverForm', function() {
               givenSubmitSpinners: popoverDOMSubmitSpinners,
             }
           )
-        formDOM.setData(initializedAttr, true)
+        formDOM.setData(initializedDataAttr, true)
 
         this._proxyFormTriggeredEvents(
           'triggerSubmit',

--- a/test/dom_components/form_tests.html
+++ b/test/dom_components/form_tests.html
@@ -13,11 +13,12 @@
         accept-charset="UTF-8"
         data-xhr-get-json-form
         data-romo-form
+        data-romo-form-redirect-page="true"
         data-romo-form-disable-focus-on-init="true">
     <input type="text" name="value" value="thing / something"
            placeholder="Enter a value.">
     <button type="submit"
-            data-romo-spinner>Submit (redirects page by default)</button>
+            data-romo-spinner>Submit (redirects page)</button>
   </form>
 
   <form action="https://api.github.com/repos/redding/romo-js"
@@ -25,12 +26,12 @@
         accept-charset="UTF-8"
         data-xhr-get-json-form
         data-romo-form
-        data-romo-form-redirect-page="false"
+        data-romo-form-xhr-response-type="json"
         data-romo-form-disable-focus-on-init="true">
     <input type="text" name="value" value="thing / something"
            placeholder="Enter a value.">
     <button type="submit"
-            data-romo-spinner>Submit (no redirect page)</button>
+            data-romo-spinner>Submit (won't redirect page by default)</button>
   </form>
 
   <div data-form-status>

--- a/test/system_tests.html
+++ b/test/system_tests.html
@@ -26,6 +26,7 @@
     </ul>
     <h3>UI Components</h3>
     <ul>
+      <li><a href="./ui/frame_tests.html">Romo.UI.Frame</a></li>
       <li><a href="./ui/nav_tests.html">Romo.UI.Nav</a></li>
       <li><a href="./ui/popover_tests.html">Romo.UI Popovers</a></li>
       <li><a href="./ui/popover_form_tests.html">Romo.UI Popover Forms</a></li>
@@ -1363,22 +1364,6 @@
     })
 
     tests.group('Romo.UI components', function() {
-      tests.test('<code>Romo.UI.Nav</code>', function(test) {
-        test.assert(Romo.UI.Nav !== undefined)
-      })
-      tests.test('<code>Romo.UI.PopoverStack</code>', function(test) {
-        test.assert(Romo.UI.PopoverStack !== undefined)
-      })
-      tests.test('<code>Romo.UI.Popover</code>', function(test) {
-        test.assert(Romo.UI.Popover !== undefined)
-        test.assert(Romo.config.popovers.headerSpacingPxFn() === 10)
-        test.assert(Romo.config.popovers.footerSpacingPxFn() === 10)
-      })
-      tests.test('<code>Romo.UI.PopoverForm</code>', function(test) {
-        test.assert(Romo.UI.PopoverForm !== undefined)
-        test.assert(Romo.config.popovers.popoverFormEditableContentCSSClassFn() === '')
-        test.assert(Romo.config.popovers.popoverFormEditableContentHoverCSSClassFn() === '')
-      })
       tests.test('<code>Romo.UI.Dropdown</code>', function(test) {
         test.assert(Romo.UI.Dropdown !== undefined)
       })
@@ -1400,6 +1385,9 @@
       tests.test('<code>Romo.UI.Dropdown.PlacementData</code>', function(test) {
         test.assert(Romo.UI.Dropdown.PlacementData !== undefined)
       })
+      tests.test('<code>Romo.UI.Frame</code>', function(test) {
+        test.assert(Romo.UI.Frame !== undefined)
+      })
       tests.test('<code>Romo.UI.Modal</code>', function(test) {
         test.assert(Romo.UI.Modal !== undefined)
       })
@@ -1414,6 +1402,22 @@
       })
       tests.test('<code>Romo.UI.Modal.PlacementData</code>', function(test) {
         test.assert(Romo.UI.Modal.PlacementData !== undefined)
+      })
+      tests.test('<code>Romo.UI.Nav</code>', function(test) {
+        test.assert(Romo.UI.Nav !== undefined)
+      })
+      tests.test('<code>Romo.UI.PopoverStack</code>', function(test) {
+        test.assert(Romo.UI.PopoverStack !== undefined)
+      })
+      tests.test('<code>Romo.UI.Popover</code>', function(test) {
+        test.assert(Romo.UI.Popover !== undefined)
+        test.assert(Romo.config.popovers.headerSpacingPxFn() === 10)
+        test.assert(Romo.config.popovers.footerSpacingPxFn() === 10)
+      })
+      tests.test('<code>Romo.UI.PopoverForm</code>', function(test) {
+        test.assert(Romo.UI.PopoverForm !== undefined)
+        test.assert(Romo.config.popovers.popoverFormEditableContentCSSClassFn() === '')
+        test.assert(Romo.config.popovers.popoverFormEditableContentHoverCSSClassFn() === '')
       })
     })
   })

--- a/test/ui/dropdowns/form/show.html
+++ b/test/ui/dropdowns/form/show.html
@@ -2,9 +2,8 @@
   <form action="https://api.github.com/repos/redding/romo-js"
         method="get"
         accept-charset="UTF-8"
-        data-romo-popover-form
-        data-romo-form-redirect-page="false"
-        data-romo-form-disable-focus-on-init="true">
+        data-romo-ui-popover-form
+        data-romo-form-xhr-response-type="json">
     <input type="text" name="value" value="thing / something"
            placeholder="Enter a value.">
     <button data-romo-ui-dropdown-popover-close>Close</button>

--- a/test/ui/frame_tests.html
+++ b/test/ui/frame_tests.html
@@ -1,0 +1,83 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="/support/romo-js/romo-ui.css"/>
+  <style>
+  </style>
+</head>
+<body style="padding-top: 25px">
+  <h1>Romo.UI.Frame system tests</h1>
+
+  <p>Frames are components that manage stacks of content and pushing and popping content onto and off of that stack. You can manually push new content on or you can use an embedded Romo.XHR or an embedded XHR Romo.Form.</p>
+
+  <div style="min-height: 100px; border: 1px solid #CCCCCC; padding: 10px;"
+       data-romo-ui-frame
+       data-frame1
+       data-current-page-num="1">
+    <div>Frame: Page 1</div>
+  </div>
+  <div style="margin-top: 5px;">
+    <button data-frame1-start-spinner>Start Spinner</button>
+    <button data-frame1-stop-spinner>Stop Spinner</button>
+    <button data-frame1-push-content>Push Content</button>
+    <button data-frame1-pop-content>Pop Content</button>
+  </div>
+
+  <div style="min-height: 100px; border: 1px solid #CCCCCC; padding: 10px; margin-top:40px"
+       data-romo-ui-frame
+       data-xhr-wizard
+       data-current-page-num="1">
+    <div>XHR Wizard: Page 1</div>
+    <div>
+      <button disabled>Prev</button>
+      <button href="./frames/xhr_wizard/show2.html"
+              data-romo-ui-frame-xhr>Next</button>
+    </div>
+  </div>
+
+  <div style="min-height: 100px; border: 1px solid #CCCCCC; padding: 10px; margin-top:40px"
+       data-romo-ui-frame
+       data-editable-frame
+       data-current-page-num="1">
+    <div>Editable Frame</div>
+    <div>
+      <button href="./frames/editable/new.html"
+              data-romo-ui-frame-xhr>New</button>
+      <button href="./frames/editable/edit.html"
+              data-romo-ui-frame-xhr>Edit</button>
+    </div>
+  </div>
+</body>
+<script type="module" src="/support/romo-js/romo-ui.js"></script>
+<script type="module" src="/support/tests.js"></script>
+<script type="module">
+  Romo.onReady(function() {
+    const frameDOM = Romo.f('[data-frame1]')
+    frameDOM.on('Romo.UI.Frame:contentPopped', function(e, romoFrame) {
+      const currentPageNum = frameDOM.data('current-page-num')
+      if (currentPageNum > 1) {
+        frameDOM.setData('current-page-num', currentPageNum - 1)
+      }
+    })
+    Romo.f('[data-frame1-start-spinner]').on('click', function() {
+      frameDOM.trigger('Romo.UI.Frame:triggerSpinnerStart')
+    })
+    Romo.f('[data-frame1-stop-spinner]').on('click', function() {
+      frameDOM.trigger('Romo.UI.Frame:triggerSpinnerStop')
+    })
+    Romo.f('[data-frame1-push-content]').on('click', function() {
+      const currentPageNum = frameDOM.data('current-page-num')
+      const newContent =
+        `<div>Frame: Page ${currentPageNum + 1}</div>` +
+        '<button data-romo-ui-frame-pop>Back</button>'
+      frameDOM.trigger('Romo.UI.Frame:triggerPushContent', [newContent])
+      frameDOM.setData('current-page-num', currentPageNum + 1)
+    })
+    Romo.f('[data-frame1-pop-content]').on('click', function() {
+      const currentPageNum = frameDOM.data('current-page-num')
+      if (currentPageNum > 1) {
+        frameDOM.trigger('Romo.UI.Frame:triggerPopContent')
+      }
+    })
+  })
+</script>

--- a/test/ui/frames/editable/create.json
+++ b/test/ui/frames/editable/create.json
@@ -1,0 +1,4 @@
+{
+  "frameContentHTML":
+    "<div>CREATED via JSON: Editable Frame</div>\n<div>\n  <button href=\"./frames/editable/new.html\"          data-romo-ui-frame-xhr>New</button>\n  <button href=\"./frames/editable/edit.html\"          data-romo-ui-frame-xhr>Edit</button></div>"
+}

--- a/test/ui/frames/editable/edit.html
+++ b/test/ui/frames/editable/edit.html
@@ -1,0 +1,12 @@
+<div style="padding: 10px">
+  <form action="./frames/editable/update.html"
+        method="get"
+        accept-charset="UTF-8"
+        data-romo-ui-frame-form>
+    <input type="text" name="value" value="thing / something"
+           placeholder="Enter a value.">
+    <button data-romo-ui-frame-pop>Close</button>
+    <button type="submit"
+            data-romo-spinner>Update</button>
+  </form>
+</div>

--- a/test/ui/frames/editable/new.html
+++ b/test/ui/frames/editable/new.html
@@ -1,0 +1,13 @@
+<div style="padding: 10px">
+  <form action="./frames/editable/create.json"
+        method="get"
+        accept-charset="UTF-8"
+        data-romo-ui-frame-form
+        data-romo-form-xhr-response-type="json">
+    <input type="text" name="value" value="thing / something"
+           placeholder="Enter a value.">
+    <button data-romo-ui-frame-pop>Close</button>
+    <button type="submit"
+            data-romo-spinner>Create</button>
+  </form>
+</div>

--- a/test/ui/frames/editable/update.html
+++ b/test/ui/frames/editable/update.html
@@ -1,0 +1,7 @@
+<div>UPDATED via HTML: Editable Frame</div>
+<div>
+  <button href="./frames/editable/new.html"
+          data-romo-ui-frame-xhr>New</button>
+  <button href="./frames/editable/edit.html"
+          data-romo-ui-frame-xhr>Edit</button>
+</div>

--- a/test/ui/frames/xhr_wizard/finish.html
+++ b/test/ui/frames/xhr_wizard/finish.html
@@ -1,0 +1,1 @@
+<div>XHR Wizard: Finished!</div>

--- a/test/ui/frames/xhr_wizard/show2.html
+++ b/test/ui/frames/xhr_wizard/show2.html
@@ -1,0 +1,6 @@
+<div>XHR Wizard: Page 2</div>
+<div>
+  <button data-romo-ui-frame-pop>Prev</button>
+  <button href="./frames/xhr_wizard/show3.html"
+          data-romo-ui-frame-xhr>Next</button>
+</div>

--- a/test/ui/frames/xhr_wizard/show3.html
+++ b/test/ui/frames/xhr_wizard/show3.html
@@ -1,0 +1,6 @@
+<div>XHR Wizard: Page 3</div>
+<div>
+  <button data-romo-ui-frame-pop>Prev</button>
+  <button href="./frames/xhr_wizard/finish.html"
+          data-romo-ui-frame-xhr>Finish</button>
+</div>

--- a/test/ui/modals/form/show.html
+++ b/test/ui/modals/form/show.html
@@ -8,9 +8,7 @@
   <form action="https://api.github.com/repos/redding/romo-js"
         method="get"
         accept-charset="UTF-8"
-        data-romo-popover-form
-        data-romo-form-redirect-page="false"
-        data-romo-form-disable-focus-on-init="true">
+        data-romo-ui-popover-form>
     <input type="text" name="value" value="thing / something"
            placeholder="Enter a value.">
   </form>


### PR DESCRIPTION
Frames are components that manage stacks of content like browser
pages manage stacks of content using the history API. Push and pop
content onto and off of a Frame manually. You can also embed
Romo.XHR or Romo.Form components to push content on submit success.

Use this component to build larger components like inline edits or
wizards.

# Other Changes

### update Romo.Form: don't default JSON responseType, don't default redirect GET submissions

This updates the Form components to not default a JSON response
type if none is specified. This is too specific of a default and
can cause surprises. A better default is to specify no response
type and return text.

This also updates the component to not default GET XHR submissions
to redirect the page. Again, this is too specific for default
behavior of an XHR Form. A better default is to just emit the
response data in the success event like Romo.XHR does. The user
can turn on the page redirection if desired.

I noticed these b/c I got surprised by them when testing Forms
embedded in the coming Romo.UI.Frame component.

### update Romo.Spinner to optionally start/stop immediately

By default, the spinner starts/stops in a `pushFn` to ensure all
other event handling is processed before starting/stopping the
Spinner. This ensures all UI mutations are done so the spinner
can lock them in when it starts. This also about being as
late-bound as possible.

However, there are times when it is necessary to _immediately_
start/stop the spinners to coordinate with other synchronous
behavior. This is usually only necessary when another component
is composing Spinner behavior into itself and needs to manage the
Spinner tightly. This updates the start/stop API to take an
optional `{start|stop}Immediately` control param to force this.

This is specifically needed for the new Romo.UI.Frame component
so it can orchestrate its use of an internal Spinner.

### don't stopPropagation of XHR/Popover click events

It is bad practice to stop the propagation of click events as
they are detected on the body element to control the PopoverStack.
I missed these previous usages when adding the PopoverStack
in a previous effort.

# Demo

Manual usage:
![frame-manual](https://user-images.githubusercontent.com/82110/105103877-eafcaa00-5a76-11eb-9162-f35a055c79b0.gif)

Wizard example, loading each wizard "page' using XHR:
![frame-wizard](https://user-images.githubusercontent.com/82110/105103891-ed5f0400-5a76-11eb-9396-dbee44dd9e0a.gif)

Inline editable content using XHR:
![frame-editable](https://user-images.githubusercontent.com/82110/105103898-efc15e00-5a76-11eb-9597-038ec4f88d4d.gif)
