### PR TITLE
add Romo.UI.LocalTime

### DIFF
--- a/lib/api/dom_attributes.js
+++ b/lib/api/dom_attributes.js
@@ -1,3 +1,8 @@
+Romo.tagName =
+  function(element) {
+    return Romo.dom(element).firstElement.tagName.toLowerCase()
+  }
+
 Romo.attr =
   function(element, attributeName) {
     return Romo.dom(element).firstElement.getAttribute(attributeName)

--- a/lib/api/dom_mutate.js
+++ b/lib/api/dom_mutate.js
@@ -66,7 +66,7 @@ Romo.updateHTML =
 
     const childDOM = Romo.dom(Romo.elements(htmlString))
     if (childDOM.length === 0) {
-      throw new Error(`"${htmlString}" doesn't contain HTML elements.`)
+      return Romo.updateText(element, htmlString)
     }
     return Romo.update(element, childDOM)
   }

--- a/lib/components/dom_component.js
+++ b/lib/components/dom_component.js
@@ -3,8 +3,25 @@
 // events.
 Romo.define('Romo.DOMComponent', function() {
   return class {
-    constructor(element) {
+    constructor(element, domDataName) {
       this.dom = Romo.dom(element)
+      this.domDataName = domDataName
+    }
+
+    domData(name) {
+      return this.dom.data(`${this.domDataName}-${name}`)
+    }
+
+    hasDOMData(name) {
+      return this.dom.hasData(`${this.domDataName}-${name}`)
+    }
+
+    setDOMData(name, dataValue) {
+      return this.dom.setData(`${this.domDataName}-${name}`, dataValue)
+    }
+
+    setDOMDataDefault(name, dataValue) {
+      return this.dom.setDataDefault(`${this.domDataName}-${name}`, dataValue)
     }
   }
 })

--- a/lib/config.js
+++ b/lib/config.js
@@ -15,6 +15,7 @@ Romo.config = new RomoConfig()
 Romo.config.alert = new RomoConfig()
 Romo.config.form = new RomoConfig()
 Romo.config.frames = new RomoConfig()
+Romo.config.localTime = new RomoConfig()
 Romo.config.popovers = new RomoConfig()
 Romo.config.tooltips = new RomoConfig()
 Romo.config.xhr = new RomoConfig()
@@ -76,6 +77,27 @@ Romo.config.form.removeErrorMessagesFn =
 Romo.config.frames.defaultSpinnerHeightPxFn =
   function(frameDOM) {
     return 45
+  }
+
+// LocalTime
+
+Romo.config.localTime.applyDateTagDefaultsFn =
+  function(romoLocalTime) {
+    romoLocalTime.setDOMDataDefault('year-format', 'numeric')
+    romoLocalTime.setDOMDataDefault('month-format', 'numeric')
+    romoLocalTime.setDOMDataDefault('day-format', 'numeric')
+  }
+
+Romo.config.localTime.applyTimeTagDefaultsFn =
+  function(romoLocalTime) {
+    romoLocalTime.setDOMDataDefault('hour-format', 'numeric')
+    romoLocalTime.setDOMDataDefault('minute-format', 'numeric')
+    if (
+      romoLocalTime.timeZone &&
+      romoLocalTime.timeZone !== romoLocalTime.class.defaultTimeZone
+    ) {
+      romoLocalTime.setDOMDataDefault('time-zone-name-format', 'short')
+    }
   }
 
 // Popovers

--- a/lib/romo-ui.css
+++ b/lib/romo-ui.css
@@ -1,6 +1,7 @@
 @import './romo.css';
 @import './ui/utilities/cursor.css';
 @import './ui/components/dropdown.css';
+@import './ui/components/local_time.css';
 @import './ui/components/modal.css';
 @import './ui/components/sortable.css';
 @import './ui/components/tooltip.css';

--- a/lib/ui/components.js
+++ b/lib/ui/components.js
@@ -1,6 +1,7 @@
 import './components/dropdown.js'
 import './components/dropdown_form.js'
 import './components/frame.js'
+import './components/local_time.js'
 import './components/modal.js'
 import './components/modal_form.js'
 import './components/nav.js'

--- a/lib/ui/components/local_time.css
+++ b/lib/ui/components/local_time.css
@@ -1,0 +1,7 @@
+[data-romo-ui-local-time]:not([data-romo-ui-local-time-formatted="true"]) {
+  visibility: hidden;
+}
+
+[data-romo-ui-local-time][data-romo-ui-local-time-formatted="true"] {
+  visibility: visible;
+}

--- a/lib/ui/components/local_time.js
+++ b/lib/ui/components/local_time.js
@@ -1,0 +1,166 @@
+// Romo.UI.LocalTime renders UTC dates/times in the browser's local time.
+Romo.define('Romo.UI.LocalTime', function() {
+  return class extends Romo.DOMComponent {
+    constructor(dom) {
+      super(dom, 'romo-ui-local-time')
+
+      this._bind()
+    }
+
+    static get defaultLocale() {
+      return (new Intl.DateTimeFormat()).resolvedOptions().locale
+    }
+
+    static get defaultTimeZone() {
+      return (new Intl.DateTimeFormat()).resolvedOptions().timeZone
+    }
+
+    get locale() {
+      return this.domData('locale')
+    }
+
+    get timeZone() {
+      return this.domData('time-zone')
+    }
+
+    get calendar() {
+      return this.domData('calendar')
+    }
+
+    get numberingSystem() {
+      return this.domData('numbering-system')
+    }
+
+    get shouldShowAsTitle() {
+      return this.domData('show-as-title') === true
+    }
+
+    get isRomoTooltip() {
+      return this.dom.hasData('romo-ui-tooltip')
+    }
+
+    get weekdayFormat() {
+      return this.domData('weekday-format')
+    }
+
+    get eraFormat() {
+      return this.domData('era-format')
+    }
+
+    get yearFormat() {
+      return this.domData('year-format')
+    }
+
+    get monthFormat() {
+      return this.domData('month-format')
+    }
+
+    get dayFormat() {
+      return this.domData('day-format')
+    }
+
+    get dayPeriodFormat() {
+      return this.domData('day-period-format')
+    }
+
+    get hourFormat() {
+      return this.domData('hour-format')
+    }
+
+    get minuteFormat() {
+      return this.domData('minute-format')
+    }
+
+    get secondFormat() {
+      return this.domData('second-format')
+    }
+
+    get fractionalSecondDigitsFormat() {
+      return this.domData('fractional-second-digits-format')
+    }
+
+    get timeZoneNameFormat() {
+      return this.domData('time-zone-name-format')
+    }
+
+    get dateTimeFormatOptions() {
+      return {
+        weekday:                this.weekdayFormat,
+        era:                    this.eraFormat,
+        year:                   this.yearFormat,
+        month:                  this.monthFormat,
+        day:                    this.dayFormat,
+        dayPeriod:              this.dayPeriodFormat,
+        hour:                   this.hourFormat,
+        minute:                 this.minuteFormat,
+        second:                 this.secondFormat,
+        fractionalSecondDigits: this.fractionalSecondDigitsFormat,
+        timeZoneName:           this.timeZoneNameFormat,
+        timeZone:               this.timeZone,
+        calendar:               this.calendar,
+        numberingSystem:        this.numberingSystem,
+      }
+    }
+
+    get encodedUTCValue() {
+      return this.domData('utc-value')
+    }
+
+    get decodedUTCValue() {
+      return Romo.memoize(this, 'decodedUTCValue', function() {
+        return new Date(Date.parse(this.encodedUTCValue))
+      })
+    }
+
+    get dateTimeFormat() {
+      return new Intl.DateTimeFormat(this.locale, this.dateTimeFormatOptions)
+    }
+
+    doRefresh() {
+      const formattedValue = this.dateTimeFormat.format(this.decodedUTCValue)
+
+      if (this.shouldShowAsTitle) {
+        this.dom.setAttr('title', formattedValue)
+      } else {
+        this.dom.rmAttr('title', formattedValue)
+      }
+      if (this.isRomoTooltip) {
+        this.dom.trigger(
+          'Romo.UI.Tooltip:triggerUpdateBubbleContent',
+          [formattedValue]
+        )
+      }
+      if (!this.shouldShowAsTitle && !this.isRomoTooltip) {
+        this.dom.updateText(formattedValue)
+      }
+
+      this.setDOMData('formatted', true)
+
+      return this
+    }
+
+    // private
+
+    _bind() {
+      this.setDOMDataDefault('locale', 'default')
+      if (this.dom.tagName() === 'date') {
+        Romo.config.localTime.applyDateTagDefaultsFn(this)
+      }
+      if (this.dom.tagName() === 'time') {
+        Romo.config.localTime.applyTimeTagDefaultsFn(this)
+      }
+      if (this.dom.tagName() === 'datetime') {
+        Romo.config.localTime.applyDateTagDefaultsFn(this)
+        Romo.config.localTime.applyTimeTagDefaultsFn(this)
+      }
+
+      this.dom.on('Romo.UI.LocalTime:triggerRefresh', Romo.bind(function(e) {
+        this.doRefresh()
+      }))
+
+      this.doRefresh()
+    }
+  }
+})
+
+Romo.addAutoInitSelector('[data-romo-ui-local-time]', Romo.UI.LocalTime)

--- a/lib/ui/components/tooltip.js
+++ b/lib/ui/components/tooltip.js
@@ -167,6 +167,10 @@ Romo.define('Romo.UI.Tooltip', function() {
         'Romo.UI.Tooltip:triggerPlaceBubble',
         Romo.bind(this._onTriggerPlaceBubble, this)
       )
+      this.dom.on(
+        'Romo.UI.Tooltip:triggerUpdateBubbleContent',
+        Romo.bind(this._onTriggerUpdateBubbleContent, this)
+      )
 
       this.hoverState = 'out'
       this.dom.on('mouseenter', Romo.bind(this._onToggleEnter, this))
@@ -198,6 +202,10 @@ Romo.define('Romo.UI.Tooltip', function() {
       if (!this.isDisabled && this.isBubbleOpen) {
         Romo.pushFn(Romo.bind(this.doPlaceBubble, this))
       }
+    }
+
+    _onTriggerUpdateBubbleContent(e, content) {
+      this.doUpdateBubbleContent(content)
     }
 
     _onToggleEnter(e) {

--- a/lib/utilities/dom.js
+++ b/lib/utilities/dom.js
@@ -110,6 +110,10 @@ Romo.define('Romo.DOM', function() {
 
     // DOM attributes API method proxies
 
+    tagName() {
+      return Romo.tagName(this)
+    }
+
     attr(attributeName) {
       return Romo.attr(this, attributeName)
     }

--- a/test/system_tests.html
+++ b/test/system_tests.html
@@ -245,6 +245,11 @@
     })
 
     tests.group('API: DOM Attributes', function() {
+      tests.test('<code>tagName</code>', function(test) {
+        const dom = Romo.f('[data-support-div-a]')
+        test.assert(dom.tagName() === 'div')
+      })
+
       tests.test('<code>attr</code>, <code>hasAttr</code>, <code>setAttr</code>, <code>rmAttr</code>', function(test) {
         const dom = Romo.f('[data-support-div-a]')
 

--- a/test/system_tests.html
+++ b/test/system_tests.html
@@ -27,6 +27,7 @@
     <h3>UI Components</h3>
     <ul>
       <li><a href="./ui/frame_tests.html">Romo.UI.Frame</a></li>
+      <li><a href="./ui/local_time_tests.html">Romo.UI.LocalTime</a></li>
       <li><a href="./ui/nav_tests.html">Romo.UI.Nav</a></li>
       <li><a href="./ui/popover_tests.html">Romo.UI Popovers</a></li>
       <li><a href="./ui/popover_form_tests.html">Romo.UI Popover Forms</a></li>
@@ -1417,6 +1418,9 @@
       })
       tests.test('<code>Romo.UI.Frame</code>', function(test) {
         test.assert(Romo.UI.Frame !== undefined)
+      })
+      tests.test('<code>Romo.UI.LocalTime</code>', function(test) {
+        test.assert(Romo.UI.LocalTime !== undefined)
       })
       tests.test('<code>Romo.UI.Modal</code>', function(test) {
         test.assert(Romo.UI.Modal !== undefined)

--- a/test/ui/local_time_tests.html
+++ b/test/ui/local_time_tests.html
@@ -1,0 +1,262 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="/support/romo-js/romo-ui.css"/>
+  <style>
+  </style>
+</head>
+<body style="padding-top: 25px">
+  <h1>Romo.UI.LocalTime system tests</h1>
+
+  <h3>date tag with no options</h3>
+  <div>
+    2021-01-23T01:23:21Z -->
+    <date data-romo-ui-local-time
+          data-romo-ui-local-time-utc-value="2021-01-23T01:23:21Z">
+    </date>
+  </div>
+
+  <h3>time tag with no options</h3>
+  <div>
+    2021-01-23T01:23:21Z -->
+    <time data-romo-ui-local-time
+          data-romo-ui-local-time-utc-value="2021-01-23T01:23:21Z">
+    </time>
+  </div>
+
+  <h3>datetime tag with no options</h3>
+  <div>
+    2021-01-23T01:23:21Z -->
+    <datetime data-romo-ui-local-time
+              data-romo-ui-local-time-utc-value="2021-01-23T01:23:21Z">
+    </datetime>
+  </div>
+
+  <h3>time tag with 'America/Los_Angeles' timezone</h3>
+  <div>
+    2021-01-23T01:23:21Z -->
+    <time data-romo-ui-local-time
+          data-romo-ui-local-time-utc-value="2021-01-23T01:23:21Z"
+          data-romo-ui-local-time-time-zone="America/Los_Angeles">
+    </time>
+  </div>
+
+  <h3>time tag with 'America/Chicago' timezone</h3>
+  <div>
+    2021-01-23T01:23:21Z -->
+    <time data-romo-ui-local-time
+          data-romo-ui-local-time-utc-value="2021-01-23T01:23:21Z"
+          data-romo-ui-local-time-time-zone="America/Chicago">
+    </time>
+  </div>
+
+  <h3>datetime tag with 'en-GB' locale</h3>
+  <div>
+    2021-01-23T01:23:21Z -->
+    <datetime data-romo-ui-local-time
+              data-romo-ui-local-time-utc-value="2021-01-23T01:23:21Z"
+              data-romo-ui-local-time-locale="en-GB">
+    </datetime>
+  </div>
+
+
+
+
+
+
+  <h3>date tag shown as the title</h3>
+  <div>
+    2021-01-23T01:23:21Z -->
+    <date data-romo-ui-local-time
+          data-romo-ui-local-time-utc-value="2021-01-23T01:23:21Z"
+          data-romo-ui-local-time-show-as-title="true">
+      About X units of time ago.
+    </date>
+  </div>
+
+  <h3>date tag shown as a Romo Tooltip</h3>
+  <div>
+    2021-01-23T01:23:21Z -->
+    <date data-romo-ui-local-time
+          data-romo-ui-local-time-utc-value="2021-01-23T01:23:21Z"
+          data-romo-ui-tooltip>
+      About X units of time ago.
+    </date>
+  </div>
+  <h3>date tag with:</h3>
+  <ul>
+    <li>data-romo-ui-local-time-weekday-format="short"</li>
+    <li>data-romo-ui-local-time-year-format="2-digit"</li>
+    <li>data-romo-ui-local-time-month-format="2-digit"</li>
+    <li>data-romo-ui-local-time-day-format="2-digit"</li>
+  </ul>
+  <div>
+    2021-01-23T01:23:21Z -->
+    <date data-romo-ui-local-time
+          data-romo-ui-local-time-weekday-format="short"
+          data-romo-ui-local-time-year-format="2-digit"
+          data-romo-ui-local-time-month-format="2-digit"
+          data-romo-ui-local-time-day-format="2-digit"
+          data-romo-ui-local-time-utc-value="2021-01-23T01:23:21Z">
+    </date>
+  </div>
+
+  <h3>date tag with:</h3>
+  <ul>
+    <li>data-romo-ui-local-time-era-format="narrow"</li>
+    <li>data-romo-ui-local-time-weekday-format="narrow"</li>
+    <li>data-romo-ui-local-time-year-format="2-digit"</li>
+    <li>data-romo-ui-local-time-month-format="2-digit"</li>
+    <li>data-romo-ui-local-time-day-format="2-digit"</li>
+  </ul>
+  <div>
+    2021-01-23T01:23:21Z -->
+    <date data-romo-ui-local-time
+          data-romo-ui-local-time-era-format="narrow"
+          data-romo-ui-local-time-weekday-format="narrow"
+          data-romo-ui-local-time-year-format="2-digit"
+          data-romo-ui-local-time-month-format="2-digit"
+          data-romo-ui-local-time-day-format="2-digit"
+          data-romo-ui-local-time-utc-value="2021-01-23T01:23:21Z">
+    </date>
+  </div>
+
+  <h3>date tag with:</h3>
+  <ul>
+    <li>data-romo-ui-local-time-era-format="short"</li>
+    <li>data-romo-ui-local-time-weekday-format="short"</li>
+    <li>data-romo-ui-local-time-year-format="numeric"</li>
+    <li>data-romo-ui-local-time-month-format="numeric"</li>
+    <li>data-romo-ui-local-time-day-format="numeric"</li>
+  </ul>
+  <div>
+    2021-01-23T01:23:21Z -->
+    <date data-romo-ui-local-time
+          data-romo-ui-local-time-era-format="short"
+          data-romo-ui-local-time-weekday-format="short"
+          data-romo-ui-local-time-year-format="numeric"
+          data-romo-ui-local-time-month-format="numeric"
+          data-romo-ui-local-time-day-format="numeric"
+          data-romo-ui-local-time-utc-value="2021-01-23T01:23:21Z">
+    </date>
+  </div>
+
+  <h3>date tag with:</h3>
+  <ul>
+    <li>data-romo-ui-local-time-era-format="long"</li>
+    <li>data-romo-ui-local-time-weekday-format="long"</li>
+    <li>data-romo-ui-local-time-year-format="numeric"</li>
+    <li>data-romo-ui-local-time-month-format="long"</li>
+    <li>data-romo-ui-local-time-day-format="numeric"</li>
+  </ul>
+  <div>
+    2021-01-23T01:23:21Z -->
+    <date data-romo-ui-local-time
+          data-romo-ui-local-time-era-format="long"
+          data-romo-ui-local-time-weekday-format="long"
+          data-romo-ui-local-time-year-format="numeric"
+          data-romo-ui-local-time-month-format="long"
+          data-romo-ui-local-time-day-format="numeric"
+          data-romo-ui-local-time-utc-value="2021-01-23T01:23:21Z">
+    </date>
+  </div>
+
+
+
+
+
+
+  <h3>time tag with no options</h3>
+  <div>
+    2021-01-23T01:23:21Z -->
+    <time data-romo-ui-local-time
+          data-romo-ui-local-time-utc-value="2021-01-23T01:23:21Z">
+    </time>
+  </div>
+
+  <h3>time tag shown as the title</h3>
+  <div>
+    2021-01-23T01:23:21Z -->
+    <time data-romo-ui-local-time
+          data-romo-ui-local-time-utc-value="2021-01-23T01:23:21Z"
+          data-romo-ui-local-time-show-as-title="true">
+      About X units of time ago.
+    </time>
+  </div>
+
+  <h3>time tag shown as a Romo Tooltip</h3>
+  <div>
+    2021-01-23T01:23:21Z -->
+    <time data-romo-ui-local-time
+          data-romo-ui-local-time-utc-value="2021-01-23T01:23:21Z"
+          data-romo-ui-tooltip>
+      About X units of time ago.
+    </time>
+  </div>
+
+  <h3>time tag with:</h3>
+  <ul>
+    <li>data-romo-ui-local-time-day-period-format="narrow"</li>
+    <li>data-romo-ui-local-time-hour-format="2-digit"</li>
+    <li>data-romo-ui-local-time-minute-format="2-digit"</li>
+    <li>data-romo-ui-local-time-second-format="2-digit"</li>
+    <li>data-romo-ui-local-time-time-zone-name-format="short"</li>
+  </ul>
+  <div>
+    2021-01-23T01:23:21Z -->
+    <time data-romo-ui-local-time
+          data-romo-ui-local-time-day-period-format="narrow"
+          data-romo-ui-local-time-hour-format="2-digit"
+          data-romo-ui-local-time-minute-format="2-digit"
+          data-romo-ui-local-time-second-format="2-digit"
+          data-romo-ui-local-time-time-zone-name-format="short"
+          data-romo-ui-local-time-utc-value="2021-01-23T01:23:21Z">
+    </time>
+  </div>
+
+  <h3>time tag with:</h3>
+  <ul>
+    <li>data-romo-ui-local-time-day-period-format="short"</li>
+    <li>data-romo-ui-local-time-hour-format="2-digit"</li>
+    <li>data-romo-ui-local-time-minute-format="2-digit"</li>
+    <li>data-romo-ui-local-time-second-format="2-digit"</li>
+    <li>data-romo-ui-local-time-time-zone-name-format="short"</li>
+  </ul>
+  <div>
+    2021-01-23T01:23:21Z -->
+    <time data-romo-ui-local-time
+          data-romo-ui-local-time-day-period-format="short"
+          data-romo-ui-local-time-hour-format="2-digit"
+          data-romo-ui-local-time-minute-format="2-digit"
+          data-romo-ui-local-time-second-format="2-digit"
+          data-romo-ui-local-time-time-zone-name-format="short"
+          data-romo-ui-local-time-utc-value="2021-01-23T01:23:21Z">
+    </time>
+  </div>
+
+  <h3>time tag with:</h3>
+  <ul>
+    <li>data-romo-ui-local-time-day-period-format="long"</li>
+    <li>data-romo-ui-local-time-hour-format="numeric"</li>
+    <li>data-romo-ui-local-time-minute-format="numeric"</li>
+    <li>data-romo-ui-local-time-second-format="numeric"</li>
+    <li>data-romo-ui-local-time-time-zone-name-format="long"</li>
+  </ul>
+  <div>
+    2021-01-23T01:23:21Z -->
+    <time data-romo-ui-local-time
+          data-romo-ui-local-time-day-period-format="long"
+          data-romo-ui-local-time-hour-format="numeric"
+          data-romo-ui-local-time-minute-format="numeric"
+          data-romo-ui-local-time-second-format="numeric"
+          data-romo-ui-local-time-time-zone-name-format="long"
+          data-romo-ui-local-time-utc-value="2021-01-23T01:23:21Z">
+    </time>
+  </div>
+</body>
+<script type="module" src="/support/romo-js/romo-ui.js"></script>
+<script type="module" src="/support/tests.js"></script>
+<script type="module">
+  Romo.onReady(function() {
+  })
+</script>


### PR DESCRIPTION
This component wraps the `Intl.DateTimeFormat` browser API and
allows interacting with it via the DOM. On init, if formats the
given UTC date/time value based on declared options and the user's
system locale/timezone and updates the DOM content with the
formatted date/time value.

This allows always formatting UTC ISO8601 date/time strings at the
server and pushes all presentation handling to the browser client
(which has the best knowledge of the user's locale/timezone etc).

It is heavily configurable but has sensible defaults for `date`,
`time`, and `datetime` tags.

# Other Changes

### add Romo.tagName DOM attribute API method

This allows you to query the tag name of a DOM element/object.
I noticed wanting this while building out Romo.UI.LocalTime.

### update Romo.updateHTML to fallback to Romo.updateText as needed

It became annoying to call `Romo.updateHTML` and then in some
scenarios the "HTML" would just be a string of text. This makes the
updateHTML API method a bit friendlier in that it will fallback
to updateText if there are no HTML elements in the given HTML
string.

I noticed this while building out Romo.UI.LocalTime's integration
with Romo.UI.Tooltip.

### update Romo.UI.Tooltip to accept update bubble content trigger events

This allows you to update the content of the bubble using only
event interactions. I ended up needing this while building out
Romo.UI.LocalTime's integration with Romo.UI.Tooltip.

### add DOM data handling methods to Romo.DOMComponent

This updates Romo.DOMComponent to optionally take a domDataName
attribute and, if given, provide utility methods for interacting
with interacting with DOM data attributes without having to
repeat the DOM data name.

This came up when building out Romo.UI.LocalTime. It has many
supported DOM data attributes and it became a pain and was noisy
repeating `romo-ui-local-time` over and over again.

In a future effort, I'll go and back-port this API to the existing
component implementations.

# Demo

![local-time-1](https://user-images.githubusercontent.com/82110/105631993-b4c47f00-5e16-11eb-81d3-be07abf33583.jpg)

