### PR TITLE
add Romo.UI.Banner

### DIFF
--- a/lib/romo-ui.css
+++ b/lib/romo-ui.css
@@ -1,3 +1,4 @@
+@import './ui/banner.css';
 @import './ui/cursor.css';
 @import './ui/dropdown.css';
 @import './ui/local_time.css';

--- a/lib/romo-ui.js
+++ b/lib/romo-ui.js
@@ -1,5 +1,6 @@
 import './core.js'
 
+import './ui/banner.js'
 import './ui/dropdown.js'
 import './ui/dropdown_form.js'
 import './ui/form.js'

--- a/lib/ui/banner.css
+++ b/lib/ui/banner.css
@@ -1,0 +1,21 @@
+:root {
+  --romo-ui-banner-container-z-index: 9999;
+  --romo-ui-banner-content-width: 640px;
+}
+
+[data-romo-ui-banner] {
+  display: none;
+}
+
+.romo-ui-banner-container {
+  position: absolute;
+  width: 100%;
+  z-index: var(--romo-ui-banner-container-z-index);
+}
+
+.romo-ui-banner-container [data-romo-ui-banner-content] {
+  height: 100%;
+  width: var(--romo-ui-banner-content-width);
+  margin: 0 auto;
+  overflow-y: scroll;
+}

--- a/lib/ui/banner.js
+++ b/lib/ui/banner.js
@@ -1,0 +1,107 @@
+import '../utilities/dom_component.js'
+
+Romo.define('Romo.UI.Banner', function() {
+  return class extends Romo.DOMComponent {
+    constructor(dom) {
+      super({
+        dom:         dom,
+        attrPrefix:  'romo-ui-banner',
+        eventPrefix: 'Romo.UI.Banner',
+      })
+
+      this._bind()
+    }
+
+    static get contentDOM() {
+      return Romo.memoize(this, 'contentDOM', function() {
+        return this.containerDOM.find('[data-romo-ui-banner-content]')
+      })
+    }
+
+    static get containerDOM() {
+      return Romo.memoize(this, 'containerDOM', function() {
+        const dom = Romo.dom(Romo.elements(this.containerTemplate))
+
+        this.bodyDOM.append(dom)
+
+        this.bodyDOM.on(
+          'Romo.UI.Banner:triggerUpdate',
+          Romo.bind(function(e, dom) {
+            this.doUpdate(dom)
+          }, this)
+        )
+        this.bodyDOM.on(
+          'Romo.UI.Banner:triggerShow',
+          Romo.bind(function(e, dom) {
+            this.doShow(dom)
+          }, this)
+        )
+        this.bodyDOM.on(
+          'Romo.UI.Banner:triggerHide',
+          Romo.bind(function(e, dom) {
+            this.doHide()
+          }, this)
+        )
+
+        return dom
+      })
+    }
+
+    static get containerTemplate() {
+      return `
+<div class="romo-ui-banner-container"
+     style="display: none;
+            top: ${Romo.config.popovers.headerSpacingPxFn()}px;
+            bottom: ${Romo.config.popovers.footerSpacingPxFn()}px">
+  <div data-romo-ui-banner-content></div>
+</div>
+`
+    }
+
+    static get bodyDOM() {
+      return Romo.memoize(this, 'bodyDOM', function() {
+        return Romo.f('body')
+      })
+    }
+
+    static doUpdate(dom) {
+      this.contentDOM.update(dom)
+      this
+        .contentDOM
+        .find('[data-romo-ui-banner-close]')
+        .on('click', Romo.bind(function(e) {
+          e.preventDefault()
+          this.doHide()
+        }, this))
+
+      this.bodyDOM.trigger('Romo.UI.Banner:updated', [this, dom])
+
+      return this
+    }
+
+    static doShow(dom) {
+      if (dom) this.doUpdate(dom)
+      this.containerDOM.show()
+      this.bodyDOM.trigger('Romo.UI.Banner:shown', [this])
+
+      return this
+    }
+
+    static doHide() {
+      this.containerDOM.hide()
+      this.bodyDOM.trigger('Romo.UI.Banner:hidden', [this])
+
+      return this
+    }
+
+    // private
+
+    _bind() {
+      this.dom.remove()
+      this.dom.rmAttr('data-romo-ui-banner')
+      this.class.doShow(this.dom)
+    }
+  }
+})
+
+Romo.addAutoInitSelector('[data-romo-ui-banner]', Romo.UI.Banner)

--- a/test/system_tests.html
+++ b/test/system_tests.html
@@ -20,6 +20,7 @@
   <div data-test-component-pages>
     <h3>UI Components</h3>
     <ul>
+      <li><a href="./ui/banner_tests.html">Romo.UI.Banner</a></li>
       <li><a href="./ui/form_tests.html">Romo.UI.Form</a></li>
       <li><a href="./ui/frame_tests.html">Romo.UI.Frame</a></li>
       <li><a href="./ui/local_time_tests.html">Romo.UI.LocalTime</a></li>
@@ -1314,6 +1315,9 @@
     })
 
     tests.group('Romo.UI components', function() {
+      tests.test('<code>Romo.UI.Banner</code>', function(test) {
+        test.assert(Romo.UI.Banner !== undefined)
+      })
       tests.test('<code>Romo.UI.Dropdown</code>', function(test) {
         test.assert(Romo.UI.Dropdown !== undefined)
       })

--- a/test/ui/banner/update.json
+++ b/test/ui/banner/update.json
@@ -1,0 +1,4 @@
+{
+  "bannerAlert":
+    "<div class=\"banner\" data-romo-ui-banner><strong>XHR Banner in Form submit JSON response</strong> <a href=\"#\" data-romo-ui-banner-close>Close</a><br/><p>This was in the JSON response to the Form submission.</p></div>"
+}

--- a/test/ui/banner/xhr.html
+++ b/test/ui/banner/xhr.html
@@ -1,0 +1,8 @@
+<div class="banner"
+     data-romo-ui-banner>
+  <strong>XHR Banner in HTML response</strong>
+  <a href="#" data-romo-ui-banner-close>Close</a>
+  <br/>
+  <p>This was in the response of the XHR request.</p>
+</div>
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed congue risus ut dui faucibus volutpat. Curabitur pretium aliquam dapibus. Aenean in viverra arcu, lobortis rhoncus est. Nullam tempus turpis quis aliquet pulvinar. Nulla sit amet ullamcorper ante. In laoreet leo eu metus molestie rutrum. Fusce sed efficitur turpis, et fringilla dui. Suspendisse gravida ex diam, tincidunt placerat turpis fringilla sed. Quisque id convallis magna. Fusce at nulla dapibus, consequat diam eu, molestie ligula. Maecenas vulputate ante ipsum, nec venenatis eros hendrerit lacinia. Pellentesque imperdiet, sapien in posuere pellentesque, ligula mi dictum tortor, ut fermentum nisi dui eget odio. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.</p>

--- a/test/ui/banner/xhr.json
+++ b/test/ui/banner/xhr.json
@@ -1,0 +1,6 @@
+{
+  "bannerAlert":
+    "<div class=\"banner\" data-romo-ui-banner><strong>XHR Banner in JSON response</strong> <a href=\"#\" data-romo-ui-banner-close>Close</a><br/><p>This was in the response of the XHR request.</p></div>",
+  "contentHTML":
+    "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed congue risus ut dui faucibus volutpat. Curabitur pretium aliquam dapibus. Aenean in viverra arcu, lobortis rhoncus est. Nullam tempus turpis quis aliquet pulvinar. Nulla sit amet ullamcorper ante. In laoreet leo eu metus molestie rutrum. Fusce sed efficitur turpis, et fringilla dui. Suspendisse gravida ex diam, tincidunt placerat turpis fringilla sed. Quisque id convallis magna. Fusce at nulla dapibus, consequat diam eu, molestie ligula. Maecenas vulputate ante ipsum, nec venenatis eros hendrerit lacinia. Pellentesque imperdiet, sapien in posuere pellentesque, ligula mi dictum tortor, ut fermentum nisi dui eget odio. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.</p>"
+}

--- a/test/ui/banner_tests.html
+++ b/test/ui/banner_tests.html
@@ -1,0 +1,82 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="/support/romo-js/romo-ui.css"/>
+  <style>
+    .banner {
+      background-color: #FFFFFF;
+      border: 1px solid #CCCCCC;
+      box-shadow: 0 5px 10px #CCCCCC;
+    }
+  </style>
+</head>
+<body style="padding-top: 25px">
+  <h1>Romo.UI.Banner system tests</h1>
+  <h3>In page markup</h3>
+  <div class="banner"
+       data-romo-ui-banner>
+    <strong>Test Banner</strong>
+    <a href="#" data-romo-ui-banner-close>Close</a>
+    <br/>
+    <p>This was in the page markup so it is immediately shown.</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed congue risus ut dui faucibus volutpat. Curabitur pretium aliquam dapibus. Aenean in viverra arcu, lobortis rhoncus est. Nullam tempus turpis quis aliquet pulvinar. Nulla sit amet ullamcorper ante. In laoreet leo eu metus molestie rutrum. Fusce sed efficitur turpis, et fringilla dui. Suspendisse gravida ex diam, tincidunt placerat turpis fringilla sed. Quisque id convallis magna. Fusce at nulla dapibus, consequat diam eu, molestie ligula. Maecenas vulputate ante ipsum, nec venenatis eros hendrerit lacinia. Pellentesque imperdiet, sapien in posuere pellentesque, ligula mi dictum tortor, ut fermentum nisi dui eget odio. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.</p>
+
+    <p>Nulla rutrum ornare mi in iaculis. Vestibulum laoreet turpis at neque venenatis malesuada. Ut tincidunt porttitor nisi, vitae sodales turpis lacinia eget. Vivamus magna lectus, dictum non sapien quis, condimentum porta libero. Nunc molestie nisi non risus mattis feugiat. Donec eu felis at augue ornare vulputate. Maecenas ornare, nisl ut faucibus interdum, metus neque euismod mi, sit amet finibus neque sapien eu sapien. Proin non nisl volutpat, placerat mi at, molestie velit. Donec mollis neque sit amet viverra condimentum. Vestibulum eu risus ultrices, elementum lorem nec, euismod sem. Nulla dignissim mollis dolor at hendrerit. Ut ut lectus fringilla, tempus justo non, congue magna. Donec scelerisque lectus eu odio fermentum tincidunt. Aliquam tincidunt nisl sed ex sollicitudin, et dictum augue iaculis.</p>
+
+    <p>Vestibulum ut convallis lacus, sed dapibus nibh. Suspendisse eleifend sollicitudin pharetra. Integer vel sagittis tortor. Sed nec tempus nunc. Mauris imperdiet nulla dignissim blandit bibendum. Etiam quis purus quis enim facilisis mollis. Sed cursus nulla quis lorem aliquet ullamcorper. Nulla in lacus a augue porta efficitur ac sed felis. Integer est velit, consequat sed mi vitae, ornare volutpat dui.</p>
+
+    <p>Nunc consectetur volutpat lorem sit amet posuere. Donec nunc enim, consequat in ipsum sed, eleifend interdum massa. Donec quam lorem, suscipit nec posuere ut, sagittis in metus. Curabitur maximus ipsum orci, sed rutrum augue blandit sit amet. Ut id scelerisque velit, nec vulputate mauris. Proin volutpat turpis sed tellus malesuada porttitor. Cras vel velit magna. Nunc bibendum nisi risus. Donec dictum non quam in maximus. Morbi id justo in felis maximus scelerisque. Etiam in dui urna. Suspendisse sed rhoncus lorem.</p>
+
+    <p>Sed mollis risus arcu, in sollicitudin quam cursus ut. Cras ut mi ut est scelerisque hendrerit in ut diam. Praesent vel tellus sed ante luctus dictum. Sed euismod elit nec nisi volutpat, sit amet porttitor nibh interdum. Curabitur volutpat egestas vestibulum. Integer in ipsum ut ligula bibendum bibendum. Quisque a dictum massa. Donec quis lacus facilisis, pulvinar nisl quis, tristique magna.</p>
+  </div>
+
+  <h3>GET XHR HTML with embedded banner markup</h3>
+  <button href="./banner/xhr.html"
+          data-xhr-html-example
+          data-romo-ui-xhr>
+    XHR HTML
+  </button>
+  <p data-xhr-html-example-content></p>
+
+  <h3>GET XHR JSON with embedded banner markup</h3>
+  <button href="./banner/xhr.json"
+          data-xhr-json-example
+          data-romo-ui-xhr
+          data-romo-ui-xhr-call-response-type="json">
+    XHR JSON
+  </button>
+  <p data-xhr-json-example-content></p>
+
+  <h3>GET Form JSON with embedded banner markup</h3>
+  <form action="./banner/update.json"
+        method="get"
+        accept-charset="UTF-8"
+        data-romo-ui-form
+        data-romo-ui-form-xhr-response-type="json">
+    <button type="submit">Update</button>
+  </form>
+</body>
+<script type="module" src="/support/romo-js/romo-ui.js"></script>
+<script type="module" src="/support/tests.js"></script>
+<script type="module">
+  Romo.onReady(function() {
+    Romo.config.alert.showBannerAlertFn =
+      function(bannerAlert) {
+        if (bannerAlert) {
+          Romo.f('body').appendHTML(bannerAlert)
+        }
+      }
+
+    Romo
+      .f('[data-xhr-html-example]')
+      .on('Romo.UI.XHR:callSuccess', function(e, romoXHR, data, xhr) {
+        Romo.f('[data-xhr-html-example-content]').updateHTML(data)
+      })
+
+    Romo
+      .f('[data-xhr-json-example]')
+      .on('Romo.UI.XHR:callSuccess', function(e, romoXHR, data, xhr) {
+        Romo.f('[data-xhr-json-example-content]').updateHTML(data.contentHTML)
+      })
+  })
+</script>


### PR DESCRIPTION
This shows alert-intended markup in a non-stack-popover that can
only be closed if a `[data-romo-ui-banner-close]` child element is
clicked OR by executing `Romo.UI.Banner.doHide`.

This is a singleton alert - only 1 set of banner markup can be
shown at a time.

The tests page demonstrates how any banners in auto-init markup
are auto-shown. It also demonstrates how banner content embedded in
XHR/Form JSON responses are also auto-shown.

# Demo

![banner-1](https://user-images.githubusercontent.com/82110/105777384-e3824880-5f2f-11eb-8dc3-0d2ca05ce040.gif)
