### PR TITLE
add Romo.UI.Toast

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -163,6 +163,7 @@ Romo.config.xhr.showJSONBannerAlertFn =
 
 Romo.config.xhr.showJSONToastAlertsFn =
   function(xhrResponseJSON) {
+    Romo.showToastAlert(xhrResponseJSON.toastAlert)
     Romo.array(xhrResponseJSON.toastAlerts).forEach(function(toastAlert) {
       Romo.showToastAlert(toastAlert)
     })

--- a/lib/romo-ui.css
+++ b/lib/romo-ui.css
@@ -5,6 +5,7 @@
 @import './ui/modal.css';
 @import './ui/sortable.css';
 @import './ui/spinner.css';
+@import './ui/toast.css';
 @import './ui/tooltip.css';
 
 html {

--- a/lib/romo-ui.js
+++ b/lib/romo-ui.js
@@ -13,6 +13,7 @@ import './ui/popover.js'
 import './ui/popover_form.js'
 import './ui/sortable.js'
 import './ui/spinner.js'
+import './ui/toast.js'
 import './ui/tooltip.js'
 import './ui/xhr.js'
 

--- a/lib/ui/banner.css
+++ b/lib/ui/banner.css
@@ -1,5 +1,5 @@
 :root {
-  --romo-ui-banner-container-z-index: 9999;
+  --romo-ui-banner-container-z-index: 9998;
   --romo-ui-banner-content-width: 640px;
 }
 
@@ -8,7 +8,7 @@
 }
 
 .romo-ui-banner-container {
-  position: absolute;
+  position: fixed;
   width: 100%;
   z-index: var(--romo-ui-banner-container-z-index);
 }

--- a/lib/ui/banner.js
+++ b/lib/ui/banner.js
@@ -66,8 +66,7 @@ Romo.define('Romo.UI.Banner', function() {
 
     static doUpdate(dom) {
       this.contentDOM.update(dom)
-      this
-        .contentDOM
+      dom
         .find('[data-romo-ui-banner-close]')
         .on('click', Romo.bind(function(e) {
           e.preventDefault()

--- a/lib/ui/toast.css
+++ b/lib/ui/toast.css
@@ -1,0 +1,24 @@
+:root {
+  --romo-ui-toast-list-z-index: 9999;
+}
+
+[data-romo-ui-toast] {
+  display: none;
+}
+
+.romo-ui-toast-list {
+  position: fixed;
+  z-index: var(--romo-ui-toast-list-z-index);
+  right: 10px;
+}
+
+[data-romo-ui-listed-toast] {
+  display: block;
+}
+
+[data-romo-ui-listed-toast].romo-ui-toast-shown {
+}
+
+[data-romo-ui-listed-toast].romo-ui-toast-dismissed {
+  display: none;
+}

--- a/lib/ui/toast.js
+++ b/lib/ui/toast.js
@@ -1,0 +1,127 @@
+import '../utilities/dom_component.js'
+
+Romo.define('Romo.UI.Toast', function() {
+  return class extends Romo.DOMComponent {
+    constructor(dom) {
+      super({
+        dom:         dom,
+        attrPrefix:  'romo-ui-toast',
+        eventPrefix: 'Romo.UI.Toast',
+      })
+
+      this._bind()
+    }
+
+    static get listDOM() {
+      return Romo.memoize(this, 'listDOM', function() {
+        const dom = Romo.dom(Romo.elements(this.listTemplate))
+
+        this.bodyDOM.append(dom)
+
+        this.bodyDOM.on(
+          'Romo.UI.Toast:triggerAdd',
+          Romo.bind(function(e, dom) {
+            this.doAdd(dom)
+          }, this)
+        )
+        this.bodyDOM.on(
+          'Romo.UI.Toast:triggerDismissAll',
+          Romo.bind(function(e, dom) {
+            this.doDismissAll()
+          }, this)
+        )
+
+        return dom
+      })
+    }
+
+    static get listTemplate() {
+      return `
+<div class="romo-ui-toast-list"
+     style="top: ${Romo.config.popovers.headerSpacingPxFn()}px">
+</div>
+`
+    }
+
+    static get bodyDOM() {
+      return Romo.memoize(this, 'bodyDOM', function() {
+        return Romo.f('body')
+      })
+    }
+
+    static doAdd(dom) {
+      this.listDOM.append(dom)
+
+      return this
+    }
+
+    static doShowAll() {
+      this
+        .listDOM
+        .find('[data-romo-ui-listed-toast]')
+        .trigger('Romo.UI.Toast:triggerShow')
+      this.bodyDOM.trigger('Romo.UI.Toast:allShown', [this])
+
+      return this
+    }
+
+    static doDismissAll() {
+      this
+        .listDOM
+        .find('[data-romo-ui-listed-toast]')
+        .trigger('Romo.UI.Toast:triggerDismiss')
+      this.bodyDOM.trigger('Romo.UI.Toast:allDismissed', [this])
+
+      return this
+    }
+
+    get bodyDOM() {
+      return this.class.bodyDOM
+    }
+
+    doShow() {
+      if (this.hasDOMClass('dismissed')) {
+        this.addDOMClass('shown')
+        this.removeDOMClass('dismissed')
+        this.bodyDOM.trigger('Romo.UI.Toast:shown', [this])
+      }
+
+      return this
+    }
+
+    doDismiss() {
+      if (this.hasDOMClass('shown') && !this.hasDOMClass('dismissed')) {
+        this.addDOMClass('dismissed')
+        this.removeDOMClass('shown')
+        this.bodyDOM.trigger('Romo.UI.Toast:dismissed', [this])
+      }
+
+      return this
+    }
+
+    // private
+
+    _bind() {
+      this.dom.remove()
+      this.dom.rmAttr('data-romo-ui-toast')
+      this.dom.setAttr('data-romo-ui-listed-toast', '')
+      this.addDOMClass('dismissed')
+
+      this.domOn('triggerShow', function(e) { this.doShow() })
+      this.domOn('triggerDismiss', function(e) { this.doDismiss() })
+      this
+        .dom
+        .find('[data-romo-ui-toast-dismiss]')
+        .on('click', Romo.bind(function(e) {
+          e.preventDefault()
+          this.doDismiss()
+        }, this))
+
+      this.class.doAdd(this.dom)
+      this.doShow()
+      this.bodyDOM.trigger('Romo.UI.Toast:added', [this])
+    }
+  }
+})
+
+Romo.addAutoInitSelector('[data-romo-ui-toast]', Romo.UI.Toast)

--- a/test/system_tests.html
+++ b/test/system_tests.html
@@ -29,6 +29,7 @@
       <li><a href="./ui/popover_form_tests.html">Romo.UI Popover Forms</a></li>
       <li><a href="./ui/sortable_tests.html">Romo.UI.Sortable</a></li>
       <li><a href="./ui/spinner_tests.html">Romo.UI.Spinner</a></li>
+      <li><a href="./ui/toast_tests.html">Romo.UI.Toast</a></li>
       <li><a href="./ui/tooltip_tests.html">Romo.UI.Tooltip</a></li>
       <li><a href="./ui/xhr_tests.html">Romo.UI.XHR</a></li>
     </ul>
@@ -1372,6 +1373,9 @@
         test.assert(Romo.UI.PopoverForm !== undefined)
         test.assert(Romo.config.popovers.popoverFormEditableContentCSSClassFn() === '')
         test.assert(Romo.config.popovers.popoverFormEditableContentHoverCSSClassFn() === '')
+      })
+      tests.test('<code>Romo.UI.Toast</code>', function(test) {
+        test.assert(Romo.UI.Toast !== undefined)
       })
       tests.test('<code>Romo.UI.Tooltip</code>', function(test) {
         test.assert(Romo.UI.Tooltip !== undefined)

--- a/test/ui/toast/update.json
+++ b/test/ui/toast/update.json
@@ -1,0 +1,7 @@
+{
+  "toastAlerts":
+    [
+      "<div class=\"toast\" data-romo-ui-toast><strong>not-animated XHR Toast #1 in Form submit JSON response</strong> <a href=\"#\" data-romo-ui-toast-dismiss>Dismiss</a><br/><p>This was in the JSON response to the Form submission.</p></div>",
+      "<div class=\"toast animated\" data-romo-ui-toast><strong>animated XHR Toast #2 in Form submit JSON response</strong> <a href=\"#\" data-romo-ui-toast-dismiss>Dismiss</a><br/><p>This was in the JSON response to the Form submission.</p></div>"
+    ]
+}

--- a/test/ui/toast/xhr.html
+++ b/test/ui/toast/xhr.html
@@ -1,0 +1,8 @@
+<div class="toast animated"
+     data-romo-ui-toast>
+  <strong>animated XHR Toast in HTML response</strong>
+  <a href="#" data-romo-ui-toast-dismiss>Dismiss</a>
+  <br/>
+  <p>This was in the response of the XHR request.</p>
+</div>
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed congue risus ut dui faucibus volutpat. Curabitur pretium aliquam dapibus. Aenean in viverra arcu, lobortis rhoncus est. Nullam tempus turpis quis aliquet pulvinar. Nulla sit amet ullamcorper ante. In laoreet leo eu metus molestie rutrum. Fusce sed efficitur turpis, et fringilla dui. Suspendisse gravida ex diam, tincidunt placerat turpis fringilla sed. Quisque id convallis magna. Fusce at nulla dapibus, consequat diam eu, molestie ligula. Maecenas vulputate ante ipsum, nec venenatis eros hendrerit lacinia. Pellentesque imperdiet, sapien in posuere pellentesque, ligula mi dictum tortor, ut fermentum nisi dui eget odio. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.</p>

--- a/test/ui/toast/xhr.json
+++ b/test/ui/toast/xhr.json
@@ -1,0 +1,6 @@
+{
+  "toastAlert":
+    "<div class=\"toast animated\" data-romo-ui-toast><strong>animated XHR Toast in JSON response</strong> <a href=\"#\" data-romo-ui-toast-dismiss>Dismiss</a><br/><p>This was in the response of the XHR request.</p></div>",
+  "contentHTML":
+    "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed congue risus ut dui faucibus volutpat. Curabitur pretium aliquam dapibus. Aenean in viverra arcu, lobortis rhoncus est. Nullam tempus turpis quis aliquet pulvinar. Nulla sit amet ullamcorper ante. In laoreet leo eu metus molestie rutrum. Fusce sed efficitur turpis, et fringilla dui. Suspendisse gravida ex diam, tincidunt placerat turpis fringilla sed. Quisque id convallis magna. Fusce at nulla dapibus, consequat diam eu, molestie ligula. Maecenas vulputate ante ipsum, nec venenatis eros hendrerit lacinia. Pellentesque imperdiet, sapien in posuere pellentesque, ligula mi dictum tortor, ut fermentum nisi dui eget odio. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.</p>"
+}

--- a/test/ui/toast_tests.html
+++ b/test/ui/toast_tests.html
@@ -1,0 +1,133 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="/support/romo-js/romo-ui.css"/>
+  <style>
+    .toast {
+      opacity: 0;
+      background-color: #FFFFFF;
+      border: 1px solid #CCCCCC;
+      box-shadow: 0 5px 10px #CCCCCC;
+      width: 320px;
+      margin-bottom: 10px;
+    }
+
+    @keyframes toast-highlight-add {
+      0% {
+        opacity: 0;
+        background-color: yellow;
+      }
+      30% {
+        opacity: 1;
+        background-color: yellow;
+      }
+      100% {
+        opacity: 1;
+        background-color: #FFFFFF;
+      }
+    }
+
+    @keyframes toast-highlight-dismiss {
+      0% {
+        margin-bottom: 10px;
+        opacity: 1;
+        background-color: pink;
+      }
+      30% {
+        margin-bottom: 10px;
+        opacity: 1;
+        background-color: pink;
+      }
+      90% {
+        margin-bottom: 10px;
+        opacity: 0;
+        background-color: pink;
+      }
+      100% {
+        margin-bottom: 0;
+        opacity: 0;
+        background-color: pink;
+        position: fixed;
+        left: 100%;
+      }
+    }
+
+    .toast:not(.animated).romo-ui-toast-shown {
+      opacity: 1;
+    }
+    .toast.animated.romo-ui-toast-shown {
+      animation: toast-highlight-add 1.5s linear forwards;
+    }
+
+    .toast:not(.animated).romo-ui-toast-dismissed {
+      margin-bottom: 0;
+      display: none;
+    }
+    .toast.animated.romo-ui-toast-dismissed {
+      display: block;
+      animation: toast-highlight-dismiss 1.5s linear forwards !important;
+    }
+  </style>
+</head>
+<body style="padding-top: 25px">
+  <h1>Romo.UI.Toast system tests</h1>
+  <h3>In page markup</h3>
+  <div class="toast"
+       data-romo-ui-toast>
+    <strong>Test Toast #1</strong>
+    <a href="#" data-romo-ui-toast-dismiss>Dismiss</a>
+    <br/>
+    <p>This was in the page markup so it is immediately shown.</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed congue risus ut dui faucibus volutpat. Curabitur pretium aliquam dapibus. Aenean in viverra arcu, lobortis rhoncus est. Nullam tempus turpis quis aliquet pulvinar. Nulla sit amet ullamcorper ante. In laoreet leo eu metus molestie rutrum. Fusce sed efficitur turpis, et fringilla dui. Suspendisse gravida ex diam, tincidunt placerat turpis fringilla sed. Quisque id convallis magna. Fusce at nulla dapibus, consequat diam eu, molestie ligula. Maecenas vulputate ante ipsum, nec venenatis eros hendrerit lacinia. Pellentesque imperdiet, sapien in posuere pellentesque, ligula mi dictum tortor, ut fermentum nisi dui eget odio. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus.</p>
+  </div>
+
+  <h3>GET XHR HTML with embedded toast markup</h3>
+  <button href="./toast/xhr.html"
+          data-xhr-html-example
+          data-romo-ui-xhr>
+    XHR HTML
+  </button>
+  <p data-xhr-html-example-content></p>
+
+  <h3>GET XHR JSON with embedded toast markup</h3>
+  <button href="./toast/xhr.json"
+          data-xhr-json-example
+          data-romo-ui-xhr
+          data-romo-ui-xhr-call-response-type="json">
+    XHR JSON
+  </button>
+  <p data-xhr-json-example-content></p>
+
+  <h3>GET Form JSON with embedded toast markup</h3>
+  <form action="./toast/update.json"
+        method="get"
+        accept-charset="UTF-8"
+        data-romo-ui-form
+        data-romo-ui-form-xhr-response-type="json">
+    <button type="submit">Update</button>
+  </form>
+</body>
+<script type="module" src="/support/romo-js/romo-ui.js"></script>
+<script type="module" src="/support/tests.js"></script>
+<script type="module">
+  Romo.onReady(function() {
+    Romo.config.alert.showToastAlertFn =
+      function(toastAlert) {
+        if (toastAlert) {
+          Romo.f('body').appendHTML(toastAlert)
+        }
+      }
+
+    Romo
+      .f('[data-xhr-html-example]')
+      .on('Romo.UI.XHR:callSuccess', function(e, romoXHR, data, xhr) {
+        Romo.f('[data-xhr-html-example-content]').updateHTML(data)
+      })
+
+    Romo
+      .f('[data-xhr-json-example]')
+      .on('Romo.UI.XHR:callSuccess', function(e, romoXHR, data, xhr) {
+        Romo.f('[data-xhr-json-example-content]').updateHTML(data.contentHTML)
+      })
+  })
+</script>


### PR DESCRIPTION
This shows alert-intended markup in a non-stack-popover that can
only be closed if a `[data-romo-ui-toast-dismiss]` child element is
clicked OR by executing `Romo.UI.Toast.doDismissAll`.

Unlinke the Romo.UI.Banner, you can show many toasts at the same
time. They list in the order they are added.

The tests page demonstrates how any toasts in auto-init markup
are auto-shown. It also demonstrates how toast content embedded in
XHR/Form JSON responses are also auto-shown. Finally the test page
also demonstrates how the CSS can be extended to animate the
toasts as they are shown/dismissed.

# Demo

![toast-1](https://user-images.githubusercontent.com/82110/105878958-3ce98680-5fc7-11eb-921d-1be339f3f5b6.gif)
