### PR TITLE
add Romo.respondTo, Romo.isDOM introspection methods

### DIFF
--- a/lib/api/define.js
+++ b/lib/api/define.js
@@ -87,6 +87,7 @@ Romo.define =
         ns[objectName] = objectFunction()
         ns[objectName].prototype.class = ns[objectName]
         ns[objectName].prototype.className = namespacedObjectName
+        ns[objectName].prototype.respondTo = Romo.respondToMethod()
         ns[objectName].wrap = Romo.wrapMethod(ns[objectName])
 
         if (object) {
@@ -136,6 +137,31 @@ Romo.wrapMethod =
         }, this))
       }, objectClass)
     )
+  }
+
+// This returns whether a property on an object is undefined or not. It is used
+// to help introspect Romo-defined objects.
+Romo.respondToMethod =
+  function() {
+    return (
+      function(messageName) {
+        return Romo.respondTo(this, messageName)
+      }
+    )
+  }
+
+// This returns whether a property on a receiver is undefined or not. It is used
+// to help introspect objects.
+Romo.respondTo =
+  function(receiver, messageName) {
+    return typeof receiver[messageName] !== 'undefined'
+  }
+
+// This returns whether an object is a Romo.DOM object. It is used to help
+// introspect objects.
+Romo.isDOM =
+  function(object) {
+    return Romo.respondTo(object, 'isRomoDOM') && object.isRomoDOM
   }
 
 // This memoizes the return value of the given fnValue function.

--- a/test/system_tests.html
+++ b/test/system_tests.html
@@ -187,14 +187,14 @@
 
     tests.group('API: Class definition', function() {
       tests.test('Class definition', function(test) {
-        Romo.define('Factory.Class', function() {
+        Romo.define('Factory.DefinedClass', function() {
           return class {}
         })
 
-        const classInstance = new Factory.Class()
+        const classInstance = new Factory.DefinedClass()
 
-        test.assert(classInstance.class === Factory.Class)
-        test.assert(classInstance.className === 'Factory.Class')
+        test.assert(classInstance.class === Factory.DefinedClass)
+        test.assert(classInstance.className === 'Factory.DefinedClass')
       })
 
       tests.test('Wrap method', function(test) {
@@ -242,6 +242,27 @@
 
         test.assert(memoizeClassInstance.memoizedValue === 1)
         test.assert(memoizeClassInstance.rawCallCount === 1)
+      })
+
+      tests.test('Introspection', function(test) {
+        Romo.define('Factory.IntrospectClass', function() {
+          return class {
+            doSomething() {
+              return this
+            }
+          }
+        })
+
+        const classInstance = new Factory.IntrospectClass()
+
+        test.assert(classInstance.respondTo('doSomething') === true)
+        test.assert(classInstance.respondTo('doAnything') === false)
+
+        test.assert(Romo.respondTo([], 'length') === true)
+
+        test.assert(Romo.isDOM(classInstance) === false)
+        test.assert(Romo.isDOM([]) === false)
+        test.assert(Romo.isDOM(Romo.dom()) === true)
       })
     })
 


### PR DESCRIPTION
The goal originally was to be able to generically ask whether any
object was a Romo.DOM instance or not. The respondTo method
available on any Romo-defined object is kinda a bonus.

# Demo

![is-dom](https://user-images.githubusercontent.com/82110/106024559-813f5a00-608d-11eb-8df4-b11c4645794e.jpg)
