### PR TITLE
add Romo.prop API; make attributes APIs consistent

### DIFF
--- a/lib/api/dom_attributes.js
+++ b/lib/api/dom_attributes.js
@@ -22,12 +22,52 @@ Romo.setAttr =
     return elements
   }
 
+// This sets an attribute to a default value if it is undefined.
+Romo.setAttrDefault =
+  function(element, attributeName, defaultValue) {
+    if (Romo.attr(element, attributeName) === null) {
+      Romo.setAttr(element, attributeName, defaultValue)
+    } else {
+      return element
+    }
+  }
+
 Romo.rmAttr =
   function(elements, attributeName) {
     Romo.dom(elements).forEachElement(function(element) {
       element.removeAttribute(attributeName)
     })
     return elements
+  }
+
+Romo.removeAttr =
+  function(elements, attributeName) {
+    return Romo.rmAttr(elements, attributeName)
+  }
+
+Romo.prop =
+  function(element, propName) {
+    return Romo.hasProp(element, propName)
+  }
+
+Romo.hasProp =
+  function(element, propName) {
+    return Romo.hasAttr(element, propName)
+  }
+
+Romo.setProp =
+  function(elements, propName) {
+    return Romo.setAttr(elements, propName, '')
+  }
+
+Romo.rmProp =
+  function(elements, propName) {
+    return Romo.rmAttr(elements, propName)
+  }
+
+Romo.removeProp =
+  function(elements, propName) {
+    return Romo.rmProp(elements, propName)
   }
 
 Romo.data =
@@ -60,6 +100,11 @@ Romo.rmData =
     return Romo.rmAttr(elements, `data-${dataName}`)
   }
 
+Romo.removeData =
+  function(elements, dataName) {
+    return Romo.rmData(elements, dataName)
+  }
+
 Romo.style =
   function(element, styleName) {
     return Romo.dom(element).firstElement.style[styleName]
@@ -89,12 +134,22 @@ Romo.rmStyle =
     return elements
   }
 
+Romo.removeStyle =
+  function(elements, styleName) {
+    return Romo.rmStyle(elements, styleName)
+  }
+
 Romo.batchRmStyle =
   function(elements, ...styles) {
     Romo.array(styles).forEach(function(styleName) {
       Romo.rmStyle(elements, styleName)
     })
     return elements
+  }
+
+Romo.batchRemoveStyle =
+  function(elements, ...styles) {
+    return Romo.batchRmStyle(elements, ...styles)
   }
 
 Romo.css =
@@ -138,6 +193,11 @@ Romo.rmClass =
       })
     })
     return elements
+  }
+
+Romo.removeClass =
+  function(elements, className) {
+    return Romo.rmClass(elements, className)
   }
 
 Romo.toggleClass =

--- a/lib/ui/form/submit_spinners.js
+++ b/lib/ui/form/submit_spinners.js
@@ -9,8 +9,7 @@ Romo.define('Romo.UI.Form.SubmitSpinners', function() {
       return (
         'button[type="submit"][data-romo-ui-spinner], ' +
         'input[type="submit"][data-romo-ui-spinner], ' +
-        '[data-romo-ui-form-submit][data-romo-ui-spinner], ' +
-        '[data-romo-ui-form-submit-spinner][data-romo-ui-spinner]'
+        '[data-romo-ui-form-submit][data-romo-ui-spinner]'
       )
     }
 

--- a/lib/ui/frame.js
+++ b/lib/ui/frame.js
@@ -105,12 +105,9 @@ Romo.define('Romo.UI.Frame', function() {
       var romoForm
       const domSubmits = this.dom.find('[data-romo-ui-form-submit]')
       const domSubmitSpinners =
-        this.dom.find(
-          '[data-romo-ui-form-submit][data-romo-ui-spinner], ' +
-          '[data-romo-ui-form-submit-spinner][data-romo-ui-spinner]'
-        )
+        this.dom.find('[data-romo-ui-form-submit][data-romo-ui-spinner]')
 
-      if (formDOM.hasElemeents) {
+      if (formDOM.hasElements) {
         romoForm =
           new Romo.UI.Form(
             formDOM,

--- a/lib/ui/toast.js
+++ b/lib/ui/toast.js
@@ -103,8 +103,8 @@ Romo.define('Romo.UI.Toast', function() {
 
     _bind() {
       this.dom.remove()
-      this.dom.rmAttr('data-romo-ui-toast')
-      this.dom.setAttr('data-romo-ui-listed-toast', '')
+      this.dom.rmProp('data-romo-ui-toast')
+      this.dom.setProp('data-romo-ui-listed-toast')
       this.addDOMClass('dismissed')
 
       this.domOn('triggerShow', function(e) { this.doShow() })

--- a/lib/utilities/dom.js
+++ b/lib/utilities/dom.js
@@ -130,8 +130,36 @@ Romo.define('Romo.DOM', function() {
       return Romo.dom(Romo.setAttr(this, attributeName, attributeValue))
     }
 
+    setAttrDefault(attributeName, defaultValue) {
+      return Romo.dom(Romo.setAttrDefault(this, attributeName, defaultValue))
+    }
+
     rmAttr(attributeName) {
       return Romo.dom(Romo.rmAttr(this, attributeName))
+    }
+
+    removeAttr(attributeName) {
+      return Romo.dom(Romo.removeAttr(this, attributeName))
+    }
+
+    prop(propName) {
+      return Romo.prop(this, propName)
+    }
+
+    hasProp(propName) {
+      return Romo.hasProp(this, propName)
+    }
+
+    setProp(propName) {
+      return Romo.dom(Romo.setProp(this, propName))
+    }
+
+    rmProp(propName) {
+      return Romo.dom(Romo.rmProp(this, propName))
+    }
+
+    removeProp(propName) {
+      return Romo.dom(Romo.removeProp(this, propName))
     }
 
     data(dataName) {
@@ -154,6 +182,10 @@ Romo.define('Romo.DOM', function() {
       return Romo.dom(Romo.rmData(this, dataName))
     }
 
+    removeData(dataName) {
+      return Romo.dom(Romo.removeData(this, dataName))
+    }
+
     style(styleName) {
       return Romo.style(this, styleName)
     }
@@ -170,8 +202,16 @@ Romo.define('Romo.DOM', function() {
       return Romo.dom(Romo.rmStyle(this, styleName))
     }
 
+    removeStyle(styleName) {
+      return Romo.dom(Romo.removeStyle(this, styleName))
+    }
+
     batchRmStyle(...styles) {
       return Romo.dom(Romo.batchRmStyle(this, ...styles))
+    }
+
+    batchRemoveStyle(...styles) {
+      return Romo.dom(Romo.batchRemoveStyle(this, ...styles))
     }
 
     css(styleName) {
@@ -191,7 +231,7 @@ Romo.define('Romo.DOM', function() {
     }
 
     removeClass(className) {
-      return this.rmClass(className)
+      return Romo.dom(Romo.removeClass(this, className))
     }
 
     toggleClass(className) {

--- a/lib/utilities/dom_component.js
+++ b/lib/utilities/dom_component.js
@@ -11,6 +11,50 @@ Romo.define('Romo.DOMComponent', function() {
       this.eventPrefix = eventPrefix
     }
 
+    domAttr(name) {
+      return this.dom.attr(`${this.attrPrefix}-${name}`)
+    }
+
+    hasDOMAttr(name) {
+      return this.dom.hasAttr(`${this.attrPrefix}-${name}`)
+    }
+
+    setDOMAttr(name, attrValue) {
+      return this.dom.setAttr(`${this.attrPrefix}-${name}`, attrValue)
+    }
+
+    setDOMAttrDefault(name, attrValue) {
+      return this.dom.setAttrDefault(`${this.attrPrefix}-${name}`, attrValue)
+    }
+
+    domProp(name) {
+      return this.dom.prop(`${this.attrPrefix}-${name}`)
+    }
+
+    hasDOMProp(name) {
+      return this.dom.hasProp(`${this.attrPrefix}-${name}`)
+    }
+
+    setDOMProp(name) {
+      return this.dom.setProp(`${this.attrPrefix}-${name}`)
+    }
+
+    hasDOMClass(className) {
+      return this.dom.hasClass(`${this.attrPrefix}-${className}`)
+    }
+
+    addDOMClass(className) {
+      return this.dom.addClass(`${this.attrPrefix}-${className}`)
+    }
+
+    rmDOMClass(className) {
+      return this.dom.rmClass(`${this.attrPrefix}-${className}`)
+    }
+
+    removeDOMClass(className) {
+      return this.dom.removeClass(`${this.attrPrefix}-${className}`)
+    }
+
     domData(name) {
       return this.dom.data(`${this.attrPrefix}-${name}`)
     }
@@ -49,22 +93,6 @@ Romo.define('Romo.DOMComponent', function() {
 
     domTrigger(customEventName, eventArgs) {
       return this.trigger(`${this.eventPrefix}:${customEventName}`, eventArgs)
-    }
-
-    hasDOMClass(className) {
-      return this.dom.hasClass(`${this.attrPrefix}-${className}`)
-    }
-
-    addDOMClass(className) {
-      return this.dom.addClass(`${this.attrPrefix}-${className}`)
-    }
-
-    rmDOMClass(className) {
-      return this.dom.rmClass(`${this.attrPrefix}-${className}`)
-    }
-
-    removeDOMClass(className) {
-      return this.dom.removeClass(`${this.attrPrefix}-${className}`)
     }
 
     pushFn(fn) {

--- a/test/system_tests.html
+++ b/test/system_tests.html
@@ -272,7 +272,7 @@
         test.assert(dom.tagName() === 'div')
       })
 
-      tests.test('<code>attr</code>, <code>hasAttr</code>, <code>setAttr</code>, <code>rmAttr</code>', function(test) {
+      tests.test('<code>attr</code>, <code>hasAttr</code>, <code>setAttr</code>, <code>rmAttr</code>, <code>removeAttr</code>', function(test) {
         const dom = Romo.f('[data-support-div-a]')
 
         const setAttrDOM = dom.setAttr('custom', 'value')
@@ -280,10 +280,42 @@
         test.assert(dom.attr('custom') === 'value')
         test.assert(setAttrDOM === dom)
 
+        const setAttrDefaultDOM = dom.setAttrDefault('custom', 1)
+        test.assert(dom.attr('custom') !== '1')
+        test.assert(setAttrDefaultDOM === dom)
+
         const rmAttrDOM = dom.rmAttr('custom')
         test.assert(dom.hasAttr('custom') === false)
         test.assert(dom.attr('custom') === null)
         test.assert(rmAttrDOM === dom)
+
+        dom.setAttrDefault('custom', 1)
+        test.assert(dom.attr('custom') === '1')
+
+        const removeAttrDOM = dom.removeAttr('custom')
+        test.assert(dom.hasAttr('custom') === false)
+        test.assert(dom.attr('custom') === null)
+        test.assert(removeAttrDOM === dom)
+      })
+
+      tests.test('<code>prop</code>, <code>hasProp</code>, <code>setProp</code>, <code>rmProp</code>, <code>removeProp</code>', function(test) {
+        const dom = Romo.f('[data-support-div-a]')
+
+        const setPropDOM = dom.setProp('custom')
+        test.assert(dom.hasProp('custom') === true)
+        test.assert(dom.prop('custom') === true)
+        test.assert(setPropDOM === dom)
+
+        const rmPropDOM = dom.rmProp('custom')
+        test.assert(dom.hasProp('custom') === false)
+        test.assert(dom.prop('custom') === false)
+        test.assert(rmPropDOM === dom)
+
+        dom.setProp('custom')
+        const removePropDOM = dom.removeProp('custom')
+        test.assert(dom.hasProp('custom') === false)
+        test.assert(dom.prop('custom') === false)
+        test.assert(removePropDOM === dom)
       })
 
       tests.test('<code>data</code>, <code>hasData</code>, <code>setData</code>, <code>rmData</code>', function(test) {
@@ -295,6 +327,10 @@
         test.assert(dom.hasAttr('data-custom') === true)
         test.assert(dom.attr('data-custom') === 'value')
         test.assert(setDataDOM === dom)
+
+        const setDataDefaultDOM = dom.setDataDefault('custom', 1)
+        test.assert(dom.data('custom') !== 1)
+        test.assert(setDataDefaultDOM === dom)
 
         dom.setData('custom', 1)
         test.assert(dom.data('custom') === 1)
@@ -321,6 +357,14 @@
         test.assert(dom.hasAttr('data-custom') === false)
         test.assert(dom.attr('data-custom') === null)
         test.assert(rmDataDOM === dom)
+
+        dom.setDataDefault('custom', 1)
+        test.assert(dom.data('custom') === 1)
+
+        const removemDataDOM = dom.removeData('custom')
+        test.assert(dom.hasData('custom') === false)
+        test.assert(dom.data('custom') === undefined)
+        test.assert(removemDataDOM === dom)
       })
 
       tests.test('<code>style</code>, <code>setStyle</code>, <code>rmStyle</code>', function(test) {
@@ -333,6 +377,11 @@
         const rmStyleDOM = dom.rmStyle('color')
         test.assert(dom.style('color') === '')
         test.assert(rmStyleDOM === dom)
+
+        dom.setStyle('color', 'red')
+        const removeStyleDOM = dom.removeStyle('color')
+        test.assert(dom.style('color') === '')
+        test.assert(removeStyleDOM === dom)
       })
 
       tests.test('<code>batchSetStyle</code>, <code>batchRmStyle</code>', function(test) {
@@ -351,6 +400,15 @@
         test.assert(dom.style('color') !== 'red')
         test.assert(dom.style('background') !== 'green')
         test.assert(batchRmStyleDOM === dom)
+
+        dom.batchSetStyle({
+          'color':      'red',
+          'background': 'green'
+        })
+        const batchRemoveStyleDOM = dom.batchRemoveStyle('color', 'background')
+        test.assert(dom.style('color') !== 'red')
+        test.assert(dom.style('background') !== 'green')
+        test.assert(batchRemoveStyleDOM === dom)
       })
 
       tests.test('<code>css</code>', function(test) {
@@ -381,7 +439,9 @@
         test.assert(dom.hasClass('custom') === true)
         test.assert(toggleClassDOM === dom)
 
-        dom.rmClass('custom')
+        const removeClassDOM = dom.removeClass('custom')
+        test.assert(dom.hasClass('custom') === false)
+        test.assert(removeClassDOM === dom)
       })
 
       tests.test('<code>show</code>, <code>hide</code>', function(test) {


### PR DESCRIPTION
This adds Romo.prop and friends. A "prop" is an attribute without
a value. This formalizes the practice and API.

This also makes the attr, prop, data, and class API feel consistent
and have consistent DOMComponent equivalents. I noticed this
inconsistency while implementing the prop API.

# Other Changes

### remove specialized Form submit spinner handling, fix a bug

I noticed this while investigating the bug fix of a typo in this
commit. We don't need to support this super esoteric method of
finding submit spinners in the interest of keeping things
simply. This is a relic of a previous implementation/take on this
I did in a different project.
