### PR TITLE
add Romo.DOMCompoent.{attr|event}Prefix properties

### DIFF
--- a/lib/ui/banner.js
+++ b/lib/ui/banner.js
@@ -3,18 +3,22 @@ import '../utilities/dom_component.js'
 Romo.define('Romo.UI.Banner', function() {
   return class extends Romo.DOMComponent {
     constructor(dom) {
-      super({
-        dom:         dom,
-        attrPrefix:  'romo-ui-banner',
-        eventPrefix: 'Romo.UI.Banner',
-      })
+      super(dom)
 
       this._bind()
     }
 
+    static get attrPrefix() {
+      return 'romo-ui-banner'
+    }
+
+    static get eventPrefix() {
+      return 'Romo.UI.Banner'
+    }
+
     static get contentDOM() {
       return Romo.memoize(this, 'contentDOM', function() {
-        return this.containerDOM.find('[data-romo-ui-banner-content]')
+        return this.containerDOM.find(`[data-${this.attrPrefix}-content]`)
       })
     }
 
@@ -25,19 +29,19 @@ Romo.define('Romo.UI.Banner', function() {
         this.bodyDOM.append(dom)
 
         this.bodyDOM.on(
-          'Romo.UI.Banner:triggerUpdate',
+          `${this.eventPrefix}:triggerUpdate`,
           Romo.bind(function(e, dom) {
             this.doUpdate(dom)
           }, this)
         )
         this.bodyDOM.on(
-          'Romo.UI.Banner:triggerShow',
+          `${this.eventPrefix}:triggerShow`,
           Romo.bind(function(e, dom) {
             this.doShow(dom)
           }, this)
         )
         this.bodyDOM.on(
-          'Romo.UI.Banner:triggerHide',
+          `${this.eventPrefix}:triggerHide`,
           Romo.bind(function(e, dom) {
             this.doHide()
           }, this)
@@ -49,11 +53,11 @@ Romo.define('Romo.UI.Banner', function() {
 
     static get containerTemplate() {
       return `
-<div class="romo-ui-banner-container"
+<div class="${this.attrPrefix}-container"
      style="display: none;
             top: ${Romo.config.popovers.headerSpacingPxFn()}px;
             bottom: ${Romo.config.popovers.footerSpacingPxFn()}px">
-  <div data-romo-ui-banner-content></div>
+  <div data-${this.attrPrefix}-content></div>
 </div>
 `
     }
@@ -73,7 +77,7 @@ Romo.define('Romo.UI.Banner', function() {
           this.doHide()
         }, this))
 
-      this.bodyDOM.trigger('Romo.UI.Banner:updated', [this, dom])
+      this.bodyDOM.trigger(`${this.eventPrefix}:updated`, [this, dom])
 
       return this
     }
@@ -81,14 +85,14 @@ Romo.define('Romo.UI.Banner', function() {
     static doShow(dom) {
       if (dom) this.doUpdate(dom)
       this.containerDOM.show()
-      this.bodyDOM.trigger('Romo.UI.Banner:shown', [this])
+      this.bodyDOM.trigger(`${this.eventPrefix}:shown`, [this])
 
       return this
     }
 
     static doHide() {
       this.containerDOM.hide()
-      this.bodyDOM.trigger('Romo.UI.Banner:hidden', [this])
+      this.bodyDOM.trigger(`${this.eventPrefix}:hidden`, [this])
 
       return this
     }
@@ -97,10 +101,10 @@ Romo.define('Romo.UI.Banner', function() {
 
     _bind() {
       this.dom.remove()
-      this.dom.rmAttr('data-romo-ui-banner')
+      this.dom.rmProp(`data-${this.attrPrefix}`)
       this.class.doShow(this.dom)
     }
   }
 })
 
-Romo.addAutoInitSelector('[data-romo-ui-banner]', Romo.UI.Banner)
+Romo.addAutoInitSelector(`[data-${Romo.UI.Banner.attrPrefix}]`, Romo.UI.Banner)

--- a/lib/ui/dropdown.js
+++ b/lib/ui/dropdown.js
@@ -7,17 +7,10 @@ import './popover.js'
 Romo.define('Romo.UI.Dropdown', function() {
   return class extends Romo.DOMComponent {
     constructor(dom) {
-      super({
-        dom:         dom,
-        attrPrefix:  'romo-ui-dropdown',
-        eventPrefix: 'Romo.UI.Dropdown',
-      })
+      super(dom)
 
       this.romoPopover =
-        new Romo.UI.Popover(this, {
-          attrPrefix:  this.attrPrefix,
-          eventPrefix: this.eventPrefix,
-        })
+        new Romo.UI.Popover(this)
 
       if (this.domData('disable-click-toggle') !== true) {
         this.on('click', function(e) {
@@ -32,6 +25,14 @@ Romo.define('Romo.UI.Dropdown', function() {
 
       this.domOn('popoverOpened', function(e) { this.dom.addClass('active') })
       this.domOn('popoverClosed', function(e) { this.dom.removeClass('active') })
+    }
+
+    static get attrPrefix() {
+      return 'romo-ui-dropdown'
+    }
+
+    static get eventPrefix() {
+      return 'Romo.UI.Dropdown'
     }
 
     static get spacingPx() {
@@ -124,11 +125,11 @@ Romo.define('Romo.UI.Dropdown', function() {
         }
 
         this.popoverDOM.setData(
-          'romo-ui-dropdown-popover-placement-position',
+          `${this.attrPrefix}-popover-placement-position`,
           placementData.position
         )
         this.popoverDOM.setData(
-          'romo-ui-dropdown-popover-placement-align',
+          `${this.attrPrefix}-popover-placement-align`,
           placementData.align
         )
 
@@ -153,5 +154,5 @@ Romo.define('Romo.UI.Dropdown', function() {
   }
 })
 
-Romo.addPopoverStackSelector('[data-romo-ui-dropdown-popover]')
-Romo.addAutoInitSelector('[data-romo-ui-dropdown]', Romo.UI.Dropdown)
+Romo.addPopoverStackSelector(`[data-${Romo.UI.Dropdown.attrPrefix}-popover]`)
+Romo.addAutoInitSelector(`[data-${Romo.UI.Dropdown.attrPrefix}]`, Romo.UI.Dropdown)

--- a/lib/ui/dropdown_form.js
+++ b/lib/ui/dropdown_form.js
@@ -7,12 +7,18 @@ Romo.define('Romo.UI.DropdownForm', function() {
       super({
         dom:               dom,
         popoverOwnerClass: Romo.UI.Dropdown,
-        attrPrefix:        'romo-ui-dropdown-form',
-        eventPrefix:       'Romo.UI.DropdownForm',
       })
       this.romoDropdown = this.romoPopoverOwner
+    }
+
+    static get attrPrefix() {
+      return 'romo-ui-dropdown-form'
+    }
+
+    static get eventPrefix() {
+      return 'Romo.UI.DropdownForm'
     }
   }
 })
 
-Romo.addAutoInitSelector('[data-romo-ui-dropdown-form]', Romo.UI.DropdownForm)
+Romo.addAutoInitSelector(`[data-${Romo.UI.DropdownForm.attrPrefix}]`, Romo.UI.DropdownForm)

--- a/lib/ui/form.js
+++ b/lib/ui/form.js
@@ -15,17 +15,21 @@ import './form/xhr_post_submission.js'
 Romo.define('Romo.UI.Form', function() {
   return class extends Romo.DOMComponent {
     constructor(dom, { givenSubmits, givenSubmitSpinners } = {}) {
-      super({
-        dom:         dom,
-        attrPrefix:  'romo-ui-form',
-        eventPrefix: 'Romo.UI.Form',
-      })
+      super(dom)
 
       this.givenSubmitsDOM = Romo.dom(givenSubmits)
       this.givenSubmitSpinnersDOM = Romo.dom(givenSubmitSpinners)
 
       // Delay the initial binding so nested components have time to bind first.
       this.pushFn(this._bind)
+    }
+
+    static get attrPrefix() {
+      return 'romo-ui-form'
+    }
+
+    static get eventPrefix() {
+      return 'Romo.UI.Form'
     }
 
     get submission() {
@@ -154,17 +158,17 @@ Romo.define('Romo.UI.Form', function() {
         'Romo.UI.Form.Submits:clicked',
         Romo.bind(function(e, _, clickedSubmitDOM) {
           if (!Romo.UI.Form.Submits.isDisabled(clickedSubmitDOM)) {
-            this.dom.trigger('Romo.UI.Form:triggerSubmit')
+            this.dom.trigger(`${this.eventPrefix}:triggerSubmit`)
           }
         }, this)
       )
 
       this.dom.on('Romo.UI.Form.OnChangeSubmits:changed', Romo.bind(function(e) {
-        this.dom.trigger('Romo.UI.Form:triggerSubmit')
+        this.dom.trigger(`${this.eventPrefix}:triggerSubmit`)
       }, this))
 
       this.dom.on('Romo.UI.Form.EnterSubmit:pressed', Romo.bind(function(e) {
-        this.dom.trigger('Romo.UI.Form:triggerSubmit')
+        this.dom.trigger(`${this.eventPrefix}:triggerSubmit`)
       }, this))
 
       // Submission Events
@@ -218,7 +222,7 @@ Romo.define('Romo.UI.Form', function() {
 
       eventNames.forEach(Romo.bind(function(eventName) {
         submissionEventName = `Romo.UI.Form.Submission:${eventName}`
-        formEventName = `Romo.UI.Form:${eventName}`
+        formEventName = `${this.eventPrefix}:${eventName}`
 
         Romo.proxyEvent({
           fromElement:   this.dom,
@@ -232,4 +236,4 @@ Romo.define('Romo.UI.Form', function() {
   }
 })
 
-Romo.addAutoInitSelector('[data-romo-ui-form]', Romo.UI.Form)
+Romo.addAutoInitSelector(`[data-${Romo.UI.Form.attrPrefix}]`, Romo.UI.Form)

--- a/lib/ui/form/base_submission.js
+++ b/lib/ui/form/base_submission.js
@@ -7,7 +7,9 @@ Romo.define('Romo.UI.Form.BaseSubmission', function() {
     }
 
     get usesConfirmation() {
-      return this.formDOM.data('romo-ui-form-confirm-submit') === true
+      return (
+        this.formDOM.data(`${Romo.UI.Form.attrPrefix}-confirm-submit`) === true
+      )
     }
 
     get isRunning() {

--- a/lib/ui/form/base_xhr_submission.js
+++ b/lib/ui/form/base_xhr_submission.js
@@ -14,7 +14,7 @@ Romo.define('Romo.UI.Form.BaseXHRSubmission', function() {
 
     get responseType() {
       return (
-        this.formDOM.data('romo-ui-form-xhr-response-type')
+        this.formDOM.data(`${Romo.UI.Form.attrPrefix}-xhr-response-type`)
       )
     }
 

--- a/lib/ui/form/enter_submit.js
+++ b/lib/ui/form/enter_submit.js
@@ -11,8 +11,12 @@ Romo.define('Romo.UI.Form.EnterSubmit', function() {
 
     isEnabled(event) {
       return (
-        this.formDOM.data('romo-ui-form-disable-enter-submit') !== true &&
-        Romo.dom(event.target).data('romo-ui-form-disable-enter-submit') !== true
+        this.formDOM.data(
+          `${Romo.UI.Form.attrPrefix}-disable-enter-submit`
+        ) !== true &&
+        Romo.dom(event.target).data(
+          `${Romo.UI.Form.attrPrefix}-disable-enter-submit`
+        ) !== true
       )
     }
 

--- a/lib/ui/form/first_visible_input.js
+++ b/lib/ui/form/first_visible_input.js
@@ -27,14 +27,17 @@ Romo.define('Romo.UI.Form.FirstVisibleInput', function() {
     get focusOnInitInputDOMs() {
       return Romo.memoize(this, 'focusOnInitInputsDOM', function() {
         return this.visibleInputDOMs.filter(function(inputDOM) {
-          return inputDOM.data('romo-ui-form-focus-on-init') === true
+          return (
+            inputDOM.data(`${Romo.UI.Form.attrPrefix}-focus-on-init`) === true
+          )
         })
       })
     }
 
     get isFocusingEnabled() {
       return (
-        this.formDOM.data('romo-ui-form-disable-focus-on-init') !== true
+        this.formDOM.data(`${Romo.UI.Form.attrPrefix}-disable-focus-on-init`) !==
+        true
       )
     }
 

--- a/lib/ui/form/on_change_submits.js
+++ b/lib/ui/form/on_change_submits.js
@@ -6,7 +6,7 @@ Romo.define('Romo.UI.Form.OnChangeSubmits', function() {
     }
 
     static get selector() {
-      return '[data-romo-ui-form-on-change-submit]'
+      return `[data-${Romo.UI.Form.attrPrefix}-on-change-submit]`
     }
 
     get onChangeSubmitsDOM() {

--- a/lib/ui/form/xhr_get_submission.js
+++ b/lib/ui/form/xhr_get_submission.js
@@ -8,15 +8,21 @@ import './values.js'
 Romo.define('Romo.UI.Form.XHRGetSubmission', function() {
   return class extends Romo.UI.Form.BaseXHRSubmission {
     get redirectPage() {
-      return this.formDOM.data('romo-ui-form-redirect-page') === true
+      return (
+        this.formDOM.data(`${Romo.UI.Form.attrPrefix}-redirect-page`) === true
+      )
     }
 
     get removeBlankGetParams() {
-      return this.formDOM.data('romo-ui-form-remove-blank-get-params') || true
+      return (
+        this.formDOM.data(`${Romo.UI.Form.attrPrefix}-remove-blank-get-params`) || true
+      )
     }
 
     get decodeGetParams() {
-      return this.formDOM.data('romo-ui-form-decode-get-params') || true
+      return (
+        this.formDOM.data(`${Romo.UI.Form.attrPrefix}-decode-get-params`) || true
+      )
     }
 
     doStartSubmit() {

--- a/lib/ui/frame.js
+++ b/lib/ui/frame.js
@@ -3,14 +3,18 @@ import '../utilities/dom_component.js'
 Romo.define('Romo.UI.Frame', function() {
   return class extends Romo.DOMComponent {
     constructor(dom) {
-      super({
-        dom:         dom,
-        attrPrefix:  'romo-ui-frame',
-        eventPrefix: 'Romo.UI.Frame',
-      })
+      super(dom)
 
       this._contentStack = []
       this._bind()
+    }
+
+    static get attrPrefix() {
+      return 'romo-ui-frame'
+    }
+
+    static get eventPrefix() {
+      return 'Romo.UI.Frame'
     }
 
     get contentStackSize() {
@@ -65,7 +69,7 @@ Romo.define('Romo.UI.Frame', function() {
     }
 
     _bindPops() {
-      this.dom.find('[data-romo-ui-frame-pop]').on(
+      this.dom.find(`[data-${Romo.UI.Frame.attrPrefix}-pop]`).on(
         'click',
         Romo.bind(function(e) {
           e.preventDefault()
@@ -75,7 +79,7 @@ Romo.define('Romo.UI.Frame', function() {
     }
 
     _bindXHRs() {
-      const xhrDOMs = this.dom.find('[data-romo-ui-frame-xhr]')
+      const xhrDOMs = this.dom.find(`[data-${Romo.UI.Frame.attrPrefix}-xhr]`)
       xhrDOMs.forEach(function(xhrDOM) {
         new Romo.UI.XHR(xhrDOM)
       })
@@ -101,7 +105,7 @@ Romo.define('Romo.UI.Frame', function() {
     }
 
     _bindForm() {
-      const formDOM = this.dom.find('[data-romo-ui-frame-form]')
+      const formDOM = this.dom.find(`[data-${Romo.UI.Frame.attrPrefix}-form]`)
       var romoForm
       const domSubmits = this.dom.find('[data-romo-ui-form-submit]')
       const domSubmitSpinners =
@@ -213,5 +217,5 @@ Romo.define('Romo.UI.Frame', function() {
   }
 })
 
-Romo.addAutoInitSelector('[data-romo-ui-frame]', Romo.UI.Frame)
-Romo.addAutoInitSelector('romo-ui-frame', Romo.UI.Frame)
+Romo.addAutoInitSelector(`[data-${Romo.UI.Frame.attrPrefix}]`, Romo.UI.Frame)
+Romo.addAutoInitSelector(`${Romo.UI.Frame.attrPrefix}`, Romo.UI.Frame)

--- a/lib/ui/infinite_scroller.js
+++ b/lib/ui/infinite_scroller.js
@@ -3,19 +3,23 @@ import '../utilities/dom_component.js'
 Romo.define('Romo.UI.InfiniteScroller', function() {
   return class extends Romo.DOMComponent {
     constructor(dom) {
-      super({
-        dom:         dom,
-        attrPrefix:  'romo-ui-infinite-scroller',
-        eventPrefix: 'Romo.UI.InfiniteScroller',
-      })
+      super(dom)
 
       this._bind()
     }
 
+    static get attrPrefix() {
+      return 'romo-ui-infinite-scroller'
+    }
+
+    static get eventPrefix() {
+      return 'Romo.UI.InfiniteScroller'
+    }
+
     static onViewChange(e) {
       Romo
-        .f('[data-romo-ui-infinite-scroller]')
-        .trigger('Romo.UI.InfiniteScroller:triggerViewChange')
+        .f(`[data-${this.attrPrefix}]`)
+        .trigger(`${this.eventPrefix}:triggerViewChange`)
     }
 
     get containerDOM() {
@@ -130,4 +134,4 @@ Romo.define('Romo.UI.InfiniteScroller', function() {
   }
 })
 
-Romo.addAutoInitSelector('[data-romo-ui-infinite-scroller]', Romo.UI.InfiniteScroller)
+Romo.addAutoInitSelector(`[data-${Romo.UI.InfiniteScroller.attrPrefix}]`, Romo.UI.InfiniteScroller)

--- a/lib/ui/local_time.js
+++ b/lib/ui/local_time.js
@@ -4,13 +4,17 @@ import '../utilities/dom_component.js'
 Romo.define('Romo.UI.LocalTime', function() {
   return class extends Romo.DOMComponent {
     constructor(dom) {
-      super({
-        dom:          dom,
-        attrPrefix:  'romo-ui-local-time',
-        eventPrefix: 'Romo.UI.LocalTime',
-      })
+      super(dom)
 
       this._bind()
+    }
+
+    static get attrPrefix() {
+      return 'romo-ui-local-time'
+    }
+
+    static get eventPrefix() {
+      return 'Romo.UI.LocalTime'
     }
 
     static get defaultLocale() {
@@ -167,4 +171,4 @@ Romo.define('Romo.UI.LocalTime', function() {
   }
 })
 
-Romo.addAutoInitSelector('[data-romo-ui-local-time]', Romo.UI.LocalTime)
+Romo.addAutoInitSelector(`[data-${Romo.UI.LocalTime.attrPrefix}]`, Romo.UI.LocalTime)

--- a/lib/ui/modal.js
+++ b/lib/ui/modal.js
@@ -7,11 +7,7 @@ import './popover.js'
 Romo.define('Romo.UI.Modal', function() {
   return class extends Romo.DOMComponent {
     constructor(dom) {
-      super({
-        dom:         dom,
-        attrPrefix:  'romo-ui-modal',
-        eventPrefix: 'Romo.UI.Modal',
-      })
+      super(dom)
 
       this.romoPopover =
         new Romo.UI.Popover(this, {
@@ -43,6 +39,14 @@ Romo.define('Romo.UI.Modal', function() {
         }, this))
         this.dragsDOM.addClass('romo-cursor-grab')
       })
+    }
+
+    static get attrPrefix() {
+      return 'romo-ui-modal'
+    }
+
+    static get eventPrefix() {
+      return 'Romo.UI.Modal'
     }
 
     static get minPlaceTopPx() {
@@ -139,5 +143,5 @@ Romo.define('Romo.UI.Modal', function() {
   }
 })
 
-Romo.addPopoverStackSelector('[data-romo-ui-modal-popover]')
-Romo.addAutoInitSelector('[data-romo-ui-modal]', Romo.UI.Modal)
+Romo.addPopoverStackSelector(`[data-${Romo.UI.Modal.attrPrefix}-popover]`)
+Romo.addAutoInitSelector(`[data-${Romo.UI.Modal.attrPrefix}]`, Romo.UI.Modal)

--- a/lib/ui/modal_form.js
+++ b/lib/ui/modal_form.js
@@ -7,13 +7,19 @@ Romo.define('Romo.UI.ModalForm', function() {
       super({
         dom:               dom,
         popoverOwnerClass: Romo.UI.Modal,
-        attrPrefix:        'romo-ui-modal-form',
-        eventPrefix:       'Romo.UI.ModalForm',
       })
       this.romoModal = this.romoPopoverOwner
       this._proxyPopoverEmittedEvents('dragMove', 'dragStart', 'dragStop')
     }
+
+    static get attrPrefix() {
+      return 'romo-ui-modal-form'
+    }
+
+    static get eventPrefix() {
+      return 'Romo.UI.ModalForm'
+    }
   }
 })
 
-Romo.addAutoInitSelector('[data-romo-ui-modal-form]', Romo.UI.ModalForm)
+Romo.addAutoInitSelector(`[data-${Romo.UI.ModalForm.attrPrefix}]`, Romo.UI.ModalForm)

--- a/lib/ui/nav.js
+++ b/lib/ui/nav.js
@@ -8,13 +8,17 @@ import './nav/link.js'
 Romo.define('Romo.UI.Nav', function() {
   return class extends Romo.DOMComponent {
     constructor(dom) {
-      super({
-        dom:         dom,
-        attrPrefix:  'romo-ui-nav',
-        eventPrefix: 'Romo.UI.Nav',
-      })
+      super(dom)
 
       this._bind()
+    }
+
+    static get attrPrefix() {
+      return 'romo-ui-nav'
+    }
+
+    static get eventPrefix() {
+      return 'Romo.UI.Nav'
     }
 
     get activeCSSClass() {
@@ -22,7 +26,7 @@ Romo.define('Romo.UI.Nav', function() {
     }
 
     get linksDOM() {
-      return this.dom.find('[data-romo-ui-nav-link]')
+      return this.dom.find(`[data-${Romo.UI.Nav.Link.attrPrefix}]`)
     }
 
     doRefresh() {
@@ -44,4 +48,4 @@ Romo.define('Romo.UI.Nav', function() {
   }
 })
 
-Romo.addAutoInitSelector('[data-romo-ui-nav]', Romo.UI.Nav)
+Romo.addAutoInitSelector(`[data-${Romo.UI.Nav.attrPrefix}]`, Romo.UI.Nav)

--- a/lib/ui/nav/link.js
+++ b/lib/ui/nav/link.js
@@ -1,14 +1,18 @@
 Romo.define('Romo.UI.Nav.Link', function() {
   return class extends Romo.DOMComponent {
     constructor(dom, { activeCSSClass } = {}) {
-      super({
-        dom:         dom,
-        attrPrefix:  'romo-ui-nav-link',
-        eventPrefix: 'Romo.UI.Nav.Link',
-      })
-      this.activeCSSClass = activeCSSClass
+      super(dom)
 
+      this.activeCSSClass = activeCSSClass
       this._bind()
+    }
+
+    static get attrPrefix() {
+      return 'romo-ui-nav-link'
+    }
+
+    static get eventPrefix() {
+      return 'Romo.UI.Nav.Link'
     }
 
     get url() {

--- a/lib/ui/popover.js
+++ b/lib/ui/popover.js
@@ -3,7 +3,7 @@ import '../utilities/dom_component.js'
 Romo.define('Romo.UI.Popover', function() {
   return class extends Romo.DOMComponent {
     constructor(popoverOwner, options) {
-      super(options)
+      super()
       this.popoverOwner = popoverOwner
       this._bindOwner()
     }
@@ -14,6 +14,14 @@ Romo.define('Romo.UI.Popover', function() {
 
     static get footerSpacingPx() {
       return Romo.config.popovers.footerSpacingPxFn()
+    }
+
+    get attrPrefix() {
+      return this.popoverOwner.attrPrefix
+    }
+
+    get eventPrefix() {
+      return this.popoverOwner.eventPrefix
     }
 
     get romoXHR() {

--- a/lib/ui/popover_form.js
+++ b/lib/ui/popover_form.js
@@ -3,12 +3,8 @@ import './form.js'
 
 Romo.define('Romo.UI.PopoverForm', function() {
   return class extends Romo.DOMComponent {
-    constructor({ dom, eventPrefix, attrPrefix, popoverOwnerClass } = {}) {
-      super({
-        dom:         dom,
-        eventPrefix: eventPrefix,
-        attrPrefix:  attrPrefix,
-      })
+    constructor({ dom, popoverOwnerClass } = {}) {
+      super(dom)
 
       this.romoPopoverOwner = new popoverOwnerClass(dom)
       this._bindPopoverOwner()

--- a/lib/ui/sortable.js
+++ b/lib/ui/sortable.js
@@ -7,13 +7,17 @@ import '../utilities/dom_component.js'
 Romo.define('Romo.UI.Sortable', function() {
   return class extends Romo.DOMComponent {
     constructor(dom) {
-      super({
-        dom:         dom,
-        attrPrefix:  'romo-ui-sortable',
-        eventPrefix: 'Romo.UI.Sortable',
-      })
+      super(dom)
 
       this._bind()
+    }
+
+    static get attrPrefix() {
+      return 'romo-ui-sortable'
+    }
+
+    static get eventPrefix() {
+      return 'Romo.UI.Sortable'
     }
 
     static get defaultSort() {
@@ -25,15 +29,15 @@ Romo.define('Romo.UI.Sortable', function() {
     }
 
     static get defaultHandle() {
-      return '[data-romo-ui-sortable-handle]'
+      return `[data-${this.attrPrefix}-handle]`
     }
 
     static get defaultGhostCSSClass() {
-      return 'romo-ui-sortable-ghost'
+      return `${this.attrPrefix}-ghost`
     }
 
     static get defaultChosenCSSClass() {
-      return 'romo-ui-sortable-chosen'
+      return `${this.attrPrefix}-chosen`
     }
 
     static get defaultAnimation() {
@@ -66,4 +70,4 @@ Romo.define('Romo.UI.Sortable', function() {
   }
 })
 
-Romo.addAutoInitSelector('[data-romo-ui-sortable]', Romo.UI.Sortable)
+Romo.addAutoInitSelector(`[data-${Romo.UI.Sortable.attrPrefix}]`, Romo.UI.Sortable)

--- a/lib/ui/spinner.js
+++ b/lib/ui/spinner.js
@@ -11,11 +11,7 @@ import '../utilities/dom_component.js'
 Romo.define('Romo.UI.Spinner', function() {
   return class extends Romo.DOMComponent {
     constructor(dom) {
-      super({
-        dom:         dom,
-        attrPrefix:  'romo-ui-spinner',
-        eventPrefix: 'Romo.UI.Spinner',
-      })
+      super(dom)
 
       this.domOn('triggerStart', function(e, basisSizePx) {
         this.doStart({ sizePx: basisSizePx })
@@ -26,9 +22,17 @@ Romo.define('Romo.UI.Spinner', function() {
       // scale better.
       if (this.stopOnPageshow !== false) {
         Romo.dom(window).on('pageshow', Romo.bind(function(e) {
-          this.dom.trigger('Romo.UI.Spinner:triggerStop')
+          this.dom.trigger(`${this.eventPrefix}:triggerStop`)
         }, this))
       }
+    }
+
+    static get attrPrefix() {
+      return 'romo-ui-spinner'
+    }
+
+    static get eventPrefix() {
+      return 'Romo.UI.Spinner'
     }
 
     get sizePx() {
@@ -165,4 +169,4 @@ Romo.define('Romo.UI.Spinner', function() {
   }
 })
 
-Romo.addAutoInitSelector('[data-romo-ui-spinner]', Romo.UI.Spinner)
+Romo.addAutoInitSelector(`[data-${Romo.UI.Spinner.attrPrefix}]`, Romo.UI.Spinner)

--- a/lib/ui/toast.js
+++ b/lib/ui/toast.js
@@ -3,13 +3,17 @@ import '../utilities/dom_component.js'
 Romo.define('Romo.UI.Toast', function() {
   return class extends Romo.DOMComponent {
     constructor(dom) {
-      super({
-        dom:         dom,
-        attrPrefix:  'romo-ui-toast',
-        eventPrefix: 'Romo.UI.Toast',
-      })
+      super(dom)
 
       this._bind()
+    }
+
+    static get attrPrefix() {
+      return 'romo-ui-toast'
+    }
+
+    static get eventPrefix() {
+      return 'Romo.UI.Toast'
     }
 
     static get listDOM() {
@@ -19,13 +23,13 @@ Romo.define('Romo.UI.Toast', function() {
         this.bodyDOM.append(dom)
 
         this.bodyDOM.on(
-          'Romo.UI.Toast:triggerAdd',
+          `${this.eventPrefix}:triggerAdd`,
           Romo.bind(function(e, dom) {
             this.doAdd(dom)
           }, this)
         )
         this.bodyDOM.on(
-          'Romo.UI.Toast:triggerDismissAll',
+          `${this.eventPrefix}:triggerDismissAll`,
           Romo.bind(function(e, dom) {
             this.doDismissAll()
           }, this)
@@ -37,7 +41,7 @@ Romo.define('Romo.UI.Toast', function() {
 
     static get listTemplate() {
       return `
-<div class="romo-ui-toast-list"
+<div class="${this.attrPrefix}-list"
      style="top: ${Romo.config.popovers.headerSpacingPxFn()}px">
 </div>
 `
@@ -59,8 +63,8 @@ Romo.define('Romo.UI.Toast', function() {
       this
         .listDOM
         .find('[data-romo-ui-listed-toast]')
-        .trigger('Romo.UI.Toast:triggerShow')
-      this.bodyDOM.trigger('Romo.UI.Toast:allShown', [this])
+        .trigger(`${this.eventPrefix}:triggerShow`)
+      this.bodyDOM.trigger(`${this.eventPrefix}:allShown`, [this])
 
       return this
     }
@@ -69,8 +73,8 @@ Romo.define('Romo.UI.Toast', function() {
       this
         .listDOM
         .find('[data-romo-ui-listed-toast]')
-        .trigger('Romo.UI.Toast:triggerDismiss')
-      this.bodyDOM.trigger('Romo.UI.Toast:allDismissed', [this])
+        .trigger(`${this.eventPrefix}:triggerDismiss`)
+      this.bodyDOM.trigger(`${this.eventPrefix}:allDismissed`, [this])
 
       return this
     }
@@ -83,7 +87,7 @@ Romo.define('Romo.UI.Toast', function() {
       if (this.hasDOMClass('dismissed')) {
         this.addDOMClass('shown')
         this.removeDOMClass('dismissed')
-        this.bodyDOM.trigger('Romo.UI.Toast:shown', [this])
+        this.bodyDOM.trigger(`${this.eventPrefix}:shown`, [this])
       }
 
       return this
@@ -93,7 +97,7 @@ Romo.define('Romo.UI.Toast', function() {
       if (this.hasDOMClass('shown') && !this.hasDOMClass('dismissed')) {
         this.addDOMClass('dismissed')
         this.removeDOMClass('shown')
-        this.bodyDOM.trigger('Romo.UI.Toast:dismissed', [this])
+        this.bodyDOM.trigger(`${this.eventPrefix}:dismissed`, [this])
       }
 
       return this
@@ -103,7 +107,7 @@ Romo.define('Romo.UI.Toast', function() {
 
     _bind() {
       this.dom.remove()
-      this.dom.rmProp('data-romo-ui-toast')
+      this.dom.rmProp(`data-${this.attrPrefix}`)
       this.dom.setProp('data-romo-ui-listed-toast')
       this.addDOMClass('dismissed')
 
@@ -111,7 +115,7 @@ Romo.define('Romo.UI.Toast', function() {
       this.domOn('triggerDismiss', function(e) { this.doDismiss() })
       this
         .dom
-        .find('[data-romo-ui-toast-dismiss]')
+        .find(`[data-${this.attrPrefix}-dismiss]`)
         .on('click', Romo.bind(function(e) {
           e.preventDefault()
           this.doDismiss()
@@ -119,9 +123,9 @@ Romo.define('Romo.UI.Toast', function() {
 
       this.class.doAdd(this.dom)
       this.doShow()
-      this.bodyDOM.trigger('Romo.UI.Toast:added', [this])
+      this.bodyDOM.trigger(`${this.eventPrefix}:added`, [this])
     }
   }
 })
 
-Romo.addAutoInitSelector('[data-romo-ui-toast]', Romo.UI.Toast)
+Romo.addAutoInitSelector(`[data-${Romo.UI.Toast.attrPrefix}]`, Romo.UI.Toast)

--- a/lib/ui/tooltip.js
+++ b/lib/ui/tooltip.js
@@ -5,14 +5,18 @@ import './tooltip/bubble.js'
 Romo.define('Romo.UI.Tooltip', function() {
   return class extends Romo.DOMComponent {
     constructor(dom) {
-      super({
-        dom:         dom,
-        attrPrefix:  'romo-ui-tooltip',
-        eventPrefix: 'Romo.UI.Tooltip',
-      })
+      super(dom)
 
       this.bubble = new Romo.UI.Tooltip.Bubble(this)
       this._bind()
+    }
+
+    static get attrPrefix() {
+      return 'romo-ui-tooltip'
+    }
+
+    static get eventPrefix() {
+      return 'Romo.UI.Tooltip'
     }
 
     static get headerSpacingPx() {
@@ -209,4 +213,4 @@ Romo.define('Romo.UI.Tooltip', function() {
   }
 })
 
-Romo.addAutoInitSelector('[data-romo-ui-tooltip]', Romo.UI.Tooltip)
+Romo.addAutoInitSelector(`[data-${Romo.UI.Tooltip.attrPrefix}]`, Romo.UI.Tooltip)

--- a/lib/ui/xhr.js
+++ b/lib/ui/xhr.js
@@ -8,13 +8,17 @@ import './spinner.js'
 Romo.define('Romo.UI.XHR', function() {
   return class extends Romo.DOMComponent {
     constructor(dom) {
-      super({
-        dom:         dom,
-        attrPrefix:  'romo-ui-xhr',
-        eventPrefix: 'Romo.UI.XHR',
-      })
+      super(dom)
 
       this._bind()
+    }
+
+    static get attrPrefix() {
+      return 'romo-ui-xhr'
+    }
+
+    static get eventPrefix() {
+      return 'Romo.UI.XHR'
     }
 
     get callUrl() {
@@ -240,4 +244,4 @@ Romo.define('Romo.UI.XHR', function() {
   }
 })
 
-Romo.addAutoInitSelector('[data-romo-ui-xhr]', Romo.UI.XHR)
+Romo.addAutoInitSelector(`[data-${Romo.UI.XHR.attrPrefix}]`, Romo.UI.XHR)

--- a/lib/utilities/dom_component.js
+++ b/lib/utilities/dom_component.js
@@ -3,12 +3,26 @@
 // events.
 Romo.define('Romo.DOMComponent', function() {
   return class {
-    constructor({ dom, attrPrefix, eventPrefix } = {}) {
+    constructor(dom) {
       if (dom) {
         this.dom = Romo.dom(dom)
       }
-      this.attrPrefix = attrPrefix
-      this.eventPrefix = eventPrefix
+    }
+
+    static get attrPrefix() {
+      throw new Error('NotImplementedError')
+    }
+
+    static get eventPrefix() {
+      throw new Error('NotImplementedError')
+    }
+
+    get attrPrefix() {
+      return this.class.attrPrefix
+    }
+
+    get eventPrefix() {
+      return this.class.eventPrefix
     }
 
     domAttr(name) {

--- a/test/system_tests.html
+++ b/test/system_tests.html
@@ -1387,10 +1387,10 @@
       tests.test('<code>Romo.DOMComponent</code>', function(test) {
         var romoDOM
 
-        romoDOM = new Romo.DOMComponent({ dom: Romo.f('body') })
+        romoDOM = new Romo.DOMComponent(Romo.f('body'))
         test.assert(romoDOM.dom.isRomoDOM === true)
 
-        romoDOM = new Romo.DOMComponent({ dom: Romo.f('body').firstElement })
+        romoDOM = new Romo.DOMComponent(Romo.f('body').firstElement)
         test.assert(romoDOM.dom.isRomoDOM === true)
       })
     })


### PR DESCRIPTION
This does another rework on these properties to make them
available at the class level, not just the instance level. This
not only makes them more available for use, it also continues to
encourage a consistent API between DOMComponents. It also has
the side-effect of failing fast if you are trying to reference
an object incorrectly. Finally it ensures attributes are named
consistently and makes any future renames easier.

I also went through all the components and made sure they were
using their own properties internally. I _may_ update the
implementations to use collaborating component properties but I'm
hesitant to right now b/c it does hurt readability. I the internal
benefits but want to evaluate it more before going full use with
it.
