### PR TITLE
update Romo.XHRCache to read from dynamic URL

### DIFF
--- a/lib/env.js
+++ b/lib/env.js
@@ -56,7 +56,9 @@ class RomoEnv {
   setup() {
     if (this._hasBeenSetup !== true) {
       Romo.childElementSet = this.childElementSet
-      this.applyAutoInitTo(Romo.f('body'))
+      Romo.pushFn(Romo.bind(function() {
+        this.applyAutoInitTo(Romo.f('body'))
+      }, this))
 
       this._hasBeenSetup = true
     }

--- a/lib/utilities/xhr_cache.js
+++ b/lib/utilities/xhr_cache.js
@@ -1,50 +1,33 @@
 Romo.define('Romo.XHRCache', function() {
   return class {
-    constructor(url, { cacheName, contentType } = {}) {
-      this.url = url
+    constructor({ cacheName, contentType } = {}) {
       this.cacheName = cacheName
       this.contentType = contentType
-
-      this._bind()
     }
 
-    doRead(fnCallback) {
-      this._read(fnCallback)
-
-      return this
-    }
-
-    doWrite(responseText) {
-      this._write(responseText)
+    doRead(url, fnCallback) {
+      this._read(url, fnCallback)
 
       return this
     }
 
     // private
 
-    get _request() {
-      return Romo.memoize(this, '_request', function() {
-        return new Request(this.url)
-      })
-    }
-
-    _bind() {
-    }
-
-    _read(fnCallback) {
+    _read(url, fnCallback) {
+      const request = this._buildRequest(url)
       window.caches.open(this.cacheName).then(Romo.bind(function(cache) {
-        cache.match(this._request).then(Romo.bind(function(response) {
+        cache.match(request).then(Romo.bind(function(response) {
           if (response) {
             response.text().then(fnCallback)
           } else {
             Romo
               .xhr({
-                url:          this.url,
+                url:          url,
                 method:       Romo.XMLHttpRequest.GET,
                 responseType: Romo.XMLHttpRequest.TEXT,
                 onSuccess:
                   Romo.bind(function(responseText, status, xhr) {
-                    this._write(responseText)
+                    this._write(request, responseText)
                     fnCallback(responseText)
                   }, this),
               })
@@ -53,14 +36,21 @@ Romo.define('Romo.XHRCache', function() {
       }, this))
     }
 
-    _write(responseText) {
+    _write(request, body) {
       window.caches.open(this.cacheName).then(Romo.bind(function(cache) {
-        cache.put(
-          this._request,
-          new Response(responseText),
-          { headers: { 'Content-Type': this.contentType } }
-        )
+        cache.put(request, this._buildResponse(body))
       }, this))
+    }
+
+    _buildRequest(url) {
+      return new Request(url)
+    }
+
+    _buildResponse(body) {
+      return new Response(
+        body,
+        { headers: { 'Content-Type': this.contentType } }
+      )
     }
   }
 })

--- a/test/system_tests.html
+++ b/test/system_tests.html
@@ -1406,6 +1406,19 @@
     tests.group('<code>Romo.XHRCache</code>', function() {
       tests.test('<code>Romo.XHRCache</code>', function(test) {
         test.assert(Romo.XHRCache !== undefined)
+
+        // expect an onSuccess handler to pass the test, fail if it isn't invoked
+        test.fail()
+
+        const xhrCache =
+          new Romo.XHRCache({
+            cacheName: 'Romo.XHRCache system tests',
+            contextType: 'text/html'
+          })
+        xhrCache.doRead('./utilities/xhr_cache/content.html', function(responseText) {
+          debugger
+          test.assert(responseText.length > 0)
+        })
       })
     })
 

--- a/test/utilities/xhr_cache/content.html
+++ b/test/utilities/xhr_cache/content.html
@@ -1,0 +1,1 @@
+<div>content</div>


### PR DESCRIPTION
Previously, the XHR cache was bound to a static URL. This meant if
the URL you wanted to read/cache changed, you had re-initialize a
new XHR Cache. This wasn't the friendliest API ever and could lead
to surprising behavior if you didn't realize the cache was bound
to the URL.

This switches to making the URL be passed in on read calls. This
means the cache is no longer bound to a single URL and can be
reused in a late-bound way on dynamic URLs.

This also fixes a bug where the content type wasn't getting set
properly on the cached responses.

Finally, this adds some system tests to ensure the utility works
as expected.

# Other Changes

### update Romo.env to push initial auto-initialization

This should allow for 3rd-party tools to define/register their own
auto init selectors and have them get initialized properly.

Previously, even though we were in an `onReady` callback, the
auto initialization was happening too soon. onReady doesn't wait
for all modules to be loaded before firing so 3rd-party modules
loaded after Romo would miss the boat.