### PR TITLE
make a bunch of cleanups based on app usage

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 node_modules/
+postcss.config.js
 test/romo.js

--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,5 @@
 bin/
 test/
 .*
+postcss.config.js
 yarn*

--- a/bin/publish_for_ui
+++ b/bin/publish_for_ui
@@ -1,5 +1,9 @@
 #!/bin/bash
 
 cp package_for_ui.json package.json
+yarn postcss lib/romo-ui.css -o lib/romo-ui.css
+
 ./bin/publish
+
 git k package.json
+git k lib/romo-ui.css

--- a/lib/api/define.js
+++ b/lib/api/define.js
@@ -88,6 +88,7 @@ Romo.define =
         ns[objectName].prototype.class = ns[objectName]
         ns[objectName].prototype.className = namespacedObjectName
         ns[objectName].prototype.respondTo = Romo.respondToMethod()
+        ns[objectName].className = namespacedObjectName
         ns[objectName].wrap = Romo.wrapMethod(ns[objectName])
 
         if (object) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -140,7 +140,7 @@ Romo.config.xhr.isSuccessStatusCode =
   }
 
 Romo.config.xhr.showErrorAlertFn =
-  function(romoXMLHttpRequest, { debugMessage } = {}) {
+  function(romoXMLHttpRequest, { debugMessage, xhr } = {}) {
     var message = 'An error occurred.'
     if (debugMessage && debugMessage.length !== 0) {
       message += `:\n${debugMessage}`

--- a/lib/config.js
+++ b/lib/config.js
@@ -14,7 +14,6 @@ class RomoConfig {}
 Romo.config = new RomoConfig()
 Romo.config.alert = new RomoConfig()
 Romo.config.form = new RomoConfig()
-Romo.config.frames = new RomoConfig()
 Romo.config.localTime = new RomoConfig()
 Romo.config.popovers = new RomoConfig()
 Romo.config.tooltips = new RomoConfig()
@@ -56,13 +55,6 @@ Romo.config.form.removeErrorMessagesFn =
       'Romo.config.form.removeErrorMessagesFn with a custom ' +
       'function that removes validation error messages from form input markup.'
     )
-  }
-
-// Frames
-
-Romo.config.frames.defaultSpinnerHeightPxFn =
-  function(frameDOM) {
-    return 45
   }
 
 // LocalTime

--- a/lib/ui/avatar.js
+++ b/lib/ui/avatar.js
@@ -12,10 +12,6 @@ Romo.define('Romo.UI.Avatar', function() {
       return 'romo-ui-avatar'
     }
 
-    static get eventPrefix() {
-      return 'Romo.UI.Avatar'
-    }
-
     static get undefinedURL() {
       return `${this.attrPrefix}-undefined`
     }

--- a/lib/ui/banner.js
+++ b/lib/ui/banner.js
@@ -12,10 +12,6 @@ Romo.define('Romo.UI.Banner', function() {
       return 'romo-ui-banner'
     }
 
-    static get eventPrefix() {
-      return 'Romo.UI.Banner'
-    }
-
     static get contentDOM() {
       return Romo.memoize(this, 'contentDOM', function() {
         return this.containerDOM.find(`[data-${this.attrPrefix}-content]`)

--- a/lib/ui/dropdown.css
+++ b/lib/ui/dropdown.css
@@ -7,7 +7,7 @@
 }
 
 [data-romo-ui-dropdown],
-[data-romo-ui-dropdown-close] {
+[data-romo-ui-dropdown-popover-close] {
   cursor: pointer;
 }
 

--- a/lib/ui/dropdown.js
+++ b/lib/ui/dropdown.js
@@ -31,10 +31,6 @@ Romo.define('Romo.UI.Dropdown', function() {
       return 'romo-ui-dropdown'
     }
 
-    static get eventPrefix() {
-      return 'Romo.UI.Dropdown'
-    }
-
     static get spacingPx() {
       return Romo.config.popovers.dropdownSpacingPxFn()
     }

--- a/lib/ui/dropdown.js
+++ b/lib/ui/dropdown.js
@@ -134,8 +134,10 @@ Romo.define('Romo.UI.Dropdown', function() {
         )
 
         this.popoverDOM.batchSetStyle({
-          top:  cssPositionData.topPx + 'px',
-          left: cssPositionData.leftPx + 'px',
+          top:    cssPositionData.top,
+          right:  cssPositionData.right,
+          bottom: cssPositionData.bottom,
+          left:   cssPositionData.left,
         })
       }
 

--- a/lib/ui/dropdown/css_position_data.js
+++ b/lib/ui/dropdown/css_position_data.js
@@ -2,46 +2,88 @@ Romo.define('Romo.UI.Dropdown.CSSPositionData', function() {
   return class {
     constructor(romoDropdown, relativeToDOM, placementData) {
       this._romoDropdown = romoDropdown
-      this._romoPopoverDOM = romoDropdown.popoverDOM
       this.relativeToDOM = relativeToDOM
       this._placementData = placementData
     }
 
-    get topPx() {
-      return Romo.memoize(this, 'topPx', function() {
-        const popoverHeightPx = this._romoPopoverDOM.firstElement.offsetHeight
+    get top() {
+      return Romo.memoize(this, 'top', function() {
         const relativeToHeightPx = Romo.height(this.relativeToDOM)
         const relativeToTopPx = this._relativeToOffset.top
-        var positionPx
+        var position
 
         switch (this._placementData.position) {
           case 'top':
-            positionPx = relativeToTopPx - popoverHeightPx - this._spacingPx
+            position = ''
             break
           case 'bottom':
-            positionPx = relativeToTopPx + relativeToHeightPx + this._spacingPx
+            position =
+              this._round(
+                relativeToTopPx + relativeToHeightPx + this._spacingPx
+              ) + 'px'
             break
         }
-        return Math.round(positionPx * 100) / 100
+        return position
       })
     }
 
-    get leftPx() {
-      return Romo.memoize(this, 'leftPx', function() {
-        const popoverWidthPx = this._romoPopoverDOM.firstElement.offsetWidth
+    get bottom() {
+      return Romo.memoize(this, 'bottom', function() {
+        const relativeToTopPx = this._relativeToOffset.top
+        var position
+
+        switch (this._placementData.position) {
+          case 'top':
+            position =
+              this._round(relativeToTopPx - this._spacingPx) + 'px'
+            position =
+              this._round(
+                this._viewportHeightPx - relativeToTopPx + this._spacingPx
+              ) + 'px'
+            break
+          case 'bottom':
+            position = ''
+            break
+        }
+        return position
+      })
+    }
+
+    get left() {
+      return Romo.memoize(this, 'left', function() {
         const relativeToLeftPx = this._relativeToOffset.left
-        const relativeToWidthPx = Romo.width(this.relativeToDOM)
-        var positionPx
+        var position
 
         switch (this._placementData.align) {
           case 'left':
-            positionPx = relativeToLeftPx
+            position = this._round(relativeToLeftPx) + 'px'
             break
           case 'right':
-            positionPx = relativeToLeftPx + relativeToWidthPx - popoverWidthPx
+            position = ''
             break
         }
-        return Math.round(positionPx * 100) / 100
+        return position
+      })
+    }
+
+    get right() {
+      return Romo.memoize(this, 'right', function() {
+        const relativeToLeftPx = this._relativeToOffset.left
+        const relativeToWidthPx = Romo.width(this.relativeToDOM)
+        var position
+
+        switch (this._placementData.align) {
+          case 'left':
+            position = ''
+            break
+          case 'right':
+            position =
+              this._round(
+                this._viewportWidthPx - relativeToLeftPx - relativeToWidthPx
+              ) + 'px'
+            break
+        }
+        return position
       })
     }
 
@@ -55,6 +97,18 @@ Romo.define('Romo.UI.Dropdown.CSSPositionData', function() {
 
     get _spacingPx() {
       return Romo.UI.Dropdown.spacingPx
+    }
+
+    get _viewportWidthPx() {
+      return document.documentElement.clientWidth
+    }
+
+    get _viewportHeightPx() {
+      return document.documentElement.clientHeight
+    }
+
+    _round(number) {
+      return Math.round(number * 100) / 100
     }
   }
 })

--- a/lib/ui/dropdown_form.js
+++ b/lib/ui/dropdown_form.js
@@ -14,10 +14,6 @@ Romo.define('Romo.UI.DropdownForm', function() {
     static get attrPrefix() {
       return 'romo-ui-dropdown-form'
     }
-
-    static get eventPrefix() {
-      return 'Romo.UI.DropdownForm'
-    }
   }
 })
 

--- a/lib/ui/form.js
+++ b/lib/ui/form.js
@@ -28,10 +28,6 @@ Romo.define('Romo.UI.Form', function() {
       return 'romo-ui-form'
     }
 
-    static get eventPrefix() {
-      return 'Romo.UI.Form'
-    }
-
     get submission() {
       if (this._submission === undefined) {
         if (this.usesBrowserSubmission) {

--- a/lib/ui/frame.js
+++ b/lib/ui/frame.js
@@ -13,10 +13,6 @@ Romo.define('Romo.UI.Frame', function() {
       return 'romo-ui-frame'
     }
 
-    static get eventPrefix() {
-      return 'Romo.UI.Frame'
-    }
-
     get contentStackSize() {
       return this._contentStack.length
     }

--- a/lib/ui/infinite_scroller.js
+++ b/lib/ui/infinite_scroller.js
@@ -12,10 +12,6 @@ Romo.define('Romo.UI.InfiniteScroller', function() {
       return 'romo-ui-infinite-scroller'
     }
 
-    static get eventPrefix() {
-      return 'Romo.UI.InfiniteScroller'
-    }
-
     static onViewChange(e) {
       Romo
         .f(`[data-${this.attrPrefix}]`)

--- a/lib/ui/local_time.js
+++ b/lib/ui/local_time.js
@@ -13,10 +13,6 @@ Romo.define('Romo.UI.LocalTime', function() {
       return 'romo-ui-local-time'
     }
 
-    static get eventPrefix() {
-      return 'Romo.UI.LocalTime'
-    }
-
     static get defaultLocale() {
       return (new Intl.DateTimeFormat()).resolvedOptions().locale
     }

--- a/lib/ui/modal.css
+++ b/lib/ui/modal.css
@@ -6,7 +6,7 @@
 }
 
 [data-romo-ui-modal],
-[data-romo-ui-modal-close] {
+[data-romo-ui-modal-popover-close] {
   cursor: pointer;
 }
 

--- a/lib/ui/modal.js
+++ b/lib/ui/modal.js
@@ -45,10 +45,6 @@ Romo.define('Romo.UI.Modal', function() {
       return 'romo-ui-modal'
     }
 
-    static get eventPrefix() {
-      return 'Romo.UI.Modal'
-    }
-
     static get minPlaceTopPx() {
       return Romo.UI.Popover.headerSpacingPx
     }

--- a/lib/ui/modal_form.js
+++ b/lib/ui/modal_form.js
@@ -15,10 +15,6 @@ Romo.define('Romo.UI.ModalForm', function() {
     static get attrPrefix() {
       return 'romo-ui-modal-form'
     }
-
-    static get eventPrefix() {
-      return 'Romo.UI.ModalForm'
-    }
   }
 })
 

--- a/lib/ui/nav.js
+++ b/lib/ui/nav.js
@@ -17,10 +17,6 @@ Romo.define('Romo.UI.Nav', function() {
       return 'romo-ui-nav'
     }
 
-    static get eventPrefix() {
-      return 'Romo.UI.Nav'
-    }
-
     get activeCSSClass() {
       return this.domData('active-css-class') || 'active'
     }

--- a/lib/ui/nav/link.js
+++ b/lib/ui/nav/link.js
@@ -11,10 +11,6 @@ Romo.define('Romo.UI.Nav.Link', function() {
       return 'romo-ui-nav-link'
     }
 
-    static get eventPrefix() {
-      return 'Romo.UI.Nav.Link'
-    }
-
     get url() {
       return Romo.memoize(this, 'url', function() {
         return Romo.url(this.domData('url') || this.dom.attr('href'))

--- a/lib/ui/on_key.js
+++ b/lib/ui/on_key.js
@@ -42,10 +42,9 @@ Romo.define('Romo.UI.OnKey', function() {
     _onKeyEvent(keyEvent) {
       clearTimeout(this.delayTimeout)
       this.delayTimeout =
-        setTimeout(
-          Romo.bind(function() { this.domTrigger('keyEvent', [keyEvent]) }, this),
-          this.delayMs
-        )
+        Romo.delayFn(this.delayMs, Romo.bind(function() {
+          this.domTrigger('keyEvent', [keyEvent])
+        }, this))
     }
   }
 })

--- a/lib/ui/on_key.js
+++ b/lib/ui/on_key.js
@@ -13,10 +13,6 @@ Romo.define('Romo.UI.OnKey', function() {
       return 'romo-ui-on-key'
     }
 
-    static get eventPrefix() {
-      return 'Romo.UI.OnKey'
-    }
-
     static get defaultKeyEvent() {
       return 'keydown'
     }

--- a/lib/ui/sortable.js
+++ b/lib/ui/sortable.js
@@ -16,10 +16,6 @@ Romo.define('Romo.UI.Sortable', function() {
       return 'romo-ui-sortable'
     }
 
-    static get eventPrefix() {
-      return 'Romo.UI.Sortable'
-    }
-
     static get defaultSort() {
       return true
     }

--- a/lib/ui/spinner.js
+++ b/lib/ui/spinner.js
@@ -31,10 +31,6 @@ Romo.define('Romo.UI.Spinner', function() {
       return 'romo-ui-spinner'
     }
 
-    static get eventPrefix() {
-      return 'Romo.UI.Spinner'
-    }
-
     get sizePx() {
       return this.domData('size-px')
     }

--- a/lib/ui/toast.js
+++ b/lib/ui/toast.js
@@ -12,10 +12,6 @@ Romo.define('Romo.UI.Toast', function() {
       return 'romo-ui-toast'
     }
 
-    static get eventPrefix() {
-      return 'Romo.UI.Toast'
-    }
-
     static get listDOM() {
       return Romo.memoize(this, 'listDOM', function() {
         const dom = Romo.dom(Romo.elements(this.listTemplate))

--- a/lib/ui/tooltip.js
+++ b/lib/ui/tooltip.js
@@ -15,10 +15,6 @@ Romo.define('Romo.UI.Tooltip', function() {
       return 'romo-ui-tooltip'
     }
 
-    static get eventPrefix() {
-      return 'Romo.UI.Tooltip'
-    }
-
     static get headerSpacingPx() {
       return Romo.config.tooltips.headerSpacingPxFn()
     }

--- a/lib/ui/xhr.js
+++ b/lib/ui/xhr.js
@@ -17,10 +17,6 @@ Romo.define('Romo.UI.XHR', function() {
       return 'romo-ui-xhr'
     }
 
-    static get eventPrefix() {
-      return 'Romo.UI.XHR'
-    }
-
     get callUrl() {
       return this.domData('call-url') || this.dom.attr('href')
     }

--- a/lib/utilities/dom_component.js
+++ b/lib/utilities/dom_component.js
@@ -14,7 +14,7 @@ Romo.define('Romo.DOMComponent', function() {
     }
 
     static get eventPrefix() {
-      throw new Error('NotImplementedError')
+      return this.className
     }
 
     get attrPrefix() {

--- a/lib/utilities/xml_http_request.js
+++ b/lib/utilities/xml_http_request.js
@@ -241,7 +241,10 @@ Romo.define('Romo.XMLHttpRequest', function() {
       if (this.errorResponseText) {
         Romo.config.xhr.showErrorAlertFn(
           this,
-          { debugMessage: this.errorResponseText },
+          {
+            debugMessage: this.errorResponseText,
+            xhr:          this.xhr,
+          },
         )
       }
     }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-standard": "^4.0.1",
     "esmify": "^2.1.1",
+    "postcss": "^8.2.4",
+    "postcss-cli": "^8.3.1",
+    "postcss-import": "^14.0.0",
     "standard": "^16.0.3"
   },
   "scripts": {

--- a/package_for_ui.json
+++ b/package_for_ui.json
@@ -13,6 +13,9 @@
     "eslint-plugin-promise": "^4.0.1",
     "eslint-plugin-standard": "^4.0.1",
     "esmify": "^2.1.1",
+    "postcss": "^8.2.4",
+    "postcss-cli": "^8.3.1",
+    "postcss-import": "^14.0.0",
     "standard": "^16.0.3"
   },
   "scripts": {

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  plugins: [
+    require('postcss-import'),
+  ]
+}

--- a/test/ui/on_key_tests.html
+++ b/test/ui/on_key_tests.html
@@ -12,7 +12,7 @@
   </style>
 </head>
 <body style="padding-top: 25px">
-  <h1>Romo.UI.Nav system tests</h1>
+  <h1>Romo.UI.OnKey system tests</h1>
   <h3>Default with no delay</h3>
   <input data-romo-ui-on-key>
 


### PR DESCRIPTION
### update Romo.UI.Dropdown placement logic to fix some bugs

Previously, the dropdown positioned itself using only the top
and left CSS attributes. To calculate the left when positioning
the dropdown on the right side of its anchor, you had to use the
popover width in the calculation. Similarly, to calculate the top
when positioning the dropdown on the top side of its anchor, you
had to use the popover height in the calculation.

Having to rely on the popover width/height in the calculations
is problematic as, in the absence of constraints, the popover
will auto resize itself as its position is altered. This means a
you have a "moving target" for your calculations and placement
bugs are inevitable.

This switches the algorithm to not rely on the width/heigh and
instead place using all 4 position options: top, right, bottom,
and left. This removes the "moving target" and therefore removed
some placement bugs.

### pass the raw XHR instance to Romo.config.xhr.showErrorAlertFn

This allows functions that change their behavior based on the
state of the XHR instance, e.g. its `status` code value. I found
myself wanting this in an app I'm using Romo on and couldn't do it.

### use PostCSS to bundle Romo.UI CSS on publish

It is a wip to download so many little individual CSS files when
the spirit of Romo.UI is that it is a single package. This is
especially so given that you can use e.g. skypack.dev to get a
single package JS import.

This adds PostCSS to the `publish_for_ui` pipeline so the CSS can
be imported as a single package import.

# Other Changes

### update Romo.UI.OnKey to use Romo.delayFn for its timeout

I should have done this originally but missed it. I want Romo
components to use Romo's API as much as possible so that if changes
are made to the API implementation, they get reflected everywhere.

### use `this.className` for default DOMComponent eventPrefix

This removes a bunch of boilerplate from the DOMComponents. I
should have thought of this originally but missed it. To implement
this, I had to also add a static className property to defined
objects.

### fix wrong selector for Dropdown/Modal close cursors

I just used the wrong selector when I originally implemented this
and didn't notice b/c I used links in the tests which get a
pointer cursor implicitly.

### remove unused Frames config API

This was originally added when I added Romo.UI.Frame b/c I thought
I'd need it. During the course of implementing that, however, I
ended up not needing it but forgot to remove it. This cleans up
the unused code.
