### PR TITLE
add configuration for Romo.UI.Avatar default URL

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -13,6 +13,7 @@ if (window.Romo === undefined) {
 class RomoConfig {}
 Romo.config = new RomoConfig()
 Romo.config.alert = new RomoConfig()
+Romo.config.avatar = new RomoConfig()
 Romo.config.form = new RomoConfig()
 Romo.config.localNumber = new RomoConfig()
 Romo.config.localTime = new RomoConfig()
@@ -36,6 +37,13 @@ Romo.config.alert.showToastAlertFn =
     if (toastAlert) {
       console.error(toastAlert)
     }
+  }
+
+// Avatar
+
+Romo.config.avatar.getDefaultURLFn =
+  function(romoAvatar) {
+    return '/romo-ui/img/default-avatar'
   }
 
 // Form

--- a/lib/ui/avatar.js
+++ b/lib/ui/avatar.js
@@ -31,11 +31,13 @@ Romo.define('Romo.UI.Avatar', function() {
     }
 
     get url() {
-      return this.domData('url') || this.class.undefinedURL
+      return this.domData('url') || this.fallbackURL
     }
 
     get fallbackURL() {
-      return this.domData('fallback-url') || this.class.undefinedURL
+      return (
+        this.domData('fallback-url') || Romo.config.avatar.getDefaultURLFn(this)
+      )
     }
 
     get imageDOM() {


### PR DESCRIPTION
This allows the user to configure their own global default avatar
URL. This also seeds the configuration with a hopefully unique
`/romo-ui/img/default-avatar` URL that:

* ...is absolute. Previously the undefined URL was relative so you
  risked accidentally matching on wildcard paths in the app.
* ...intention revealing. The URL hints at what it is looking for.

Finally this tweaks the main URL to use the fallback URL if no
value is specified. The fallback URL uses the configured default
URL if no value is specified. This is just to try and ensure there
is a value for the attributes and setup the precedence of those
values.
