### PR TITLE
update Romo.UI.Dropdown to support ad-hoc open CSS classes

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -146,6 +146,11 @@ Romo.config.popovers.dropdownSpacingPxFn =
     return 2
   }
 
+Romo.config.popovers.dropdownBaseOpenCSSClassFn =
+  function() {
+    return 'active'
+  }
+
 Romo.config.popovers.headerSpacingPxFn =
   function() {
     return 10

--- a/lib/ui/dropdown.js
+++ b/lib/ui/dropdown.js
@@ -23,8 +23,12 @@ Romo.define('Romo.UI.Dropdown', function() {
         })
       }
 
-      this.domOn('popoverOpened', function(e) { this.dom.addClass('active') })
-      this.domOn('popoverClosed', function(e) { this.dom.removeClass('active') })
+      this.domOn('popoverOpened', function(e) {
+        this.dom.addClass(this.openCSSClass)
+      })
+      this.domOn('popoverClosed', function(e) {
+        this.dom.removeClass(this.openCSSClass)
+      })
     }
 
     static get attrPrefix() {
@@ -37,6 +41,10 @@ Romo.define('Romo.UI.Dropdown', function() {
 
     static get defaultPadPx() {
       return Romo.config.popovers.defaultPadPxFn()
+    }
+
+    static get baseOpenCSSClass() {
+      return Romo.config.popovers.dropdownBaseOpenCSSClassFn()
     }
 
     get isDisabled() {
@@ -57,6 +65,12 @@ Romo.define('Romo.UI.Dropdown', function() {
 
     get defaultPlacementAlign() {
       return this._defaultPlacementConfig.align
+    }
+
+    get openCSSClass() {
+      return (
+        `${this.class.baseOpenCSSClass} ${this.domData('open-css-class')}`
+      )
     }
 
     get popoverDOM() {

--- a/test/ui/popover_tests.html
+++ b/test/ui/popover_tests.html
@@ -3,6 +3,9 @@
 <head>
   <link rel="stylesheet" type="text/css" href="/support/romo-js/romo-ui.css"/>
   <style>
+    .bg-red {
+      background-color: red;
+    }
   </style>
 </head>
 <body style="padding-top: 25px">
@@ -317,6 +320,26 @@
         <code>
           href="..."<br />
           data-romo-ui-dropdown
+        </code>
+      </td>
+    </tr>
+    <tr>
+      <td style="padding:10px; text-align: left; vertical-align: top; border: 1px solid #CCCCCC">
+        Custom open CSS class<br />
+        (adds the to the base open CSS class)
+      </td>
+      <td style="padding:10px; text-align: left; vertical-align: top; border: 1px solid #CCCCCC">
+        <button href="./dropdowns/basic/show.html"
+                data-romo-ui-dropdown
+                data-romo-ui-dropdown-open-css-class="bg-red">
+          Custom open CSS class
+        </button>
+      </td>
+      <td style="padding:10px; text-align: left; vertical-align: top; border: 1px solid #CCCCCC">
+        <code>
+          href="..."<br />
+          data-romo-ui-dropdown<br />
+          data-romo-ui-dropdown-open-css-class="bg-red"
         </code>
       </td>
     </tr>


### PR DESCRIPTION
These CSS classes are set when the dropdown is open and removed
when the dropdown is closed. Use this to set custom styles to
help indicate an active dropdown is open.

This also adds the ability to configure the base open CSS value.
By default it is 'active'. This base CSS class is always added
when the dropdown is open, in addition to any ad-hoc CSS classes.

# Demo

(will upload the demo gif once my internet is stable)


