### PR TITLE
add Romo.UI.DatePicker component mixin

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -14,6 +14,7 @@ class RomoConfig {}
 Romo.config = new RomoConfig()
 Romo.config.alert = new RomoConfig()
 Romo.config.avatar = new RomoConfig()
+Romo.config.datePicker = new RomoConfig()
 Romo.config.form = new RomoConfig()
 Romo.config.indicatorTextInput = new RomoConfig()
 Romo.config.localNumber = new RomoConfig()
@@ -45,6 +46,55 @@ Romo.config.alert.showToastAlertFn =
 Romo.config.avatar.getDefaultURLFn =
   function(romoAvatar) {
     return '/romo-ui/img/default-avatar'
+  }
+
+// DatePicker
+
+Romo.config.datePicker.defaultIndicatorIconNameFn =
+  function(romoDatePicker) {
+    return ''
+  }
+
+Romo.config.datePicker.defaultIndicatorIconCSSClassFn =
+  function(romoDatePicker) {
+    return ''
+  }
+
+Romo.config.datePicker.defaultIndicatorPositionFn =
+  function(romoDatePicker) {
+    return 'right'
+  }
+
+Romo.config.datePicker.defaultIndicatorSpacingPxFn =
+  function(romoDatePicker) {
+    return undefined
+  }
+
+Romo.config.datePicker.defaultIndicatorWidthPxFn =
+  function(romoDatePicker) {
+    return undefined
+  }
+
+Romo.config.datePicker.defaultIndicatorSpinnerSizePxFn =
+  function(romoDatePicker) {
+    return undefined
+  }
+
+Romo.config.datePicker.defaultFormatFn =
+  function(romoDatePicker) {
+    return (
+      Romo.UI.LocalTime.defaultLocale === 'en-US' ? 'mm/dd/yyyy' : 'yyyy-mm-dd'
+    )
+  }
+
+Romo.config.datePicker.calendarPrevMonthMarkupFn =
+  function() {
+    return '<<'
+  }
+
+Romo.config.datePicker.calendarNextMonthMarkupFn =
+  function() {
+    return '>>'
   }
 
 // Form

--- a/lib/romo-ui.css
+++ b/lib/romo-ui.css
@@ -1,5 +1,6 @@
 @import './ui/banner.css';
 @import './ui/cursor.css';
+@import './ui/date_picker.css';
 @import './ui/dropdown.css';
 @import './ui/indicator_text_input.css';
 @import './ui/local_number.css';

--- a/lib/romo-ui.js
+++ b/lib/romo-ui.js
@@ -2,6 +2,7 @@ import './core.js'
 
 import './ui/avatar.js'
 import './ui/banner.js'
+import './ui/date_picker.js'
 import './ui/dropdown.js'
 import './ui/dropdown_form.js'
 import './ui/form.js'

--- a/lib/ui/date_picker.css
+++ b/lib/ui/date_picker.css
@@ -1,0 +1,62 @@
+:root {
+  --romo-ui-date-picker-calendar-color: #000000;
+  --romo-ui-date-picker-calendar-background-color: #FFFFFF;
+  --romo-ui-date-picker-calendar-weekend-background-color: #ECECEC;
+  --romo-ui-date-picker-calendar-highlight-background-color: #357EDD;
+  --romo-ui-date-picker-calendar-highlight-day-color: var(--romo-ui-date-picker-calendar-background-color);
+  --romo-ui-date-picker-calendar-disabled-day-color: #999999;
+  --romo-ui-date-picker-calendar-other-month-day-color: #999999;
+  --romo-ui-date-picker-calendar-today-day-color: var(--romo-ui-date-picker-calendar-color);
+  --romo-ui-date-picker-calendar-today-border-color: var(--romo-ui-date-picker-calendar-color);
+}
+
+table.romo-ui-date-picker-calendar {
+  background-color: var(--romo-ui-date-picker-calendar-background-color);
+  color: var(--romo-ui-date-picker-calendar-color);
+  user-select: none;
+
+  border-collapse: none;
+  border-spacing: 0;
+  width: 100%;
+}
+
+.romo-ui-date-picker-calendar th,
+.romo-ui-date-picker-calendar td {
+  width: 14.285714286%; /* 100% / 7 */
+  text-align: center;
+}
+
+.romo-ui-date-picker-calendar [data-romo-ui-date-picker-calendar-prev],
+.romo-ui-date-picker-calendar [data-romo-ui-date-picker-calendar-next],
+.romo-ui-date-picker-calendar td:not(.disabled) {
+  cursor: pointer;
+}
+
+.romo-ui-date-picker-calendar [data-romo-ui-date-picker-calendar-prev]:hover,
+.romo-ui-date-picker-calendar [data-romo-ui-date-picker-calendar-next]:hover {
+  background-color: var(--romo-ui-date-picker-calendar-highlight-background-color) !important;
+  color: var(--romo-ui-date-picker-calendar-highlight-day-color) !important;
+}
+
+.romo-ui-date-picker-calendar td.weekend {
+  background-color: var(--romo-ui-date-picker-calendar-weekend-background-color);
+}
+
+.romo-ui-date-picker-calendar td.highlight {
+  background-color: var(--romo-ui-date-picker-calendar-highlight-background-color) !important;
+  color: var(--romo-ui-date-picker-calendar-highlight-day-color) !important;
+}
+
+.romo-ui-date-picker-calendar td.disabled {
+  color: var(--romo-ui-date-picker-calendar-disabled-day-color);
+  cursor: not-allowed;
+}
+
+.romo-ui-date-picker-calendar td.other-month {
+  color: var(--romo-ui-date-picker-calendar-other-month-day-color);
+}
+
+.romo-ui-date-picker-calendar td.today {
+  border: 1px solid var(--romo-ui-date-picker-calendar-today-border-color);
+  color: var(--romo-ui-date-picker-calendar-today-day-color);
+}

--- a/lib/ui/date_picker.js
+++ b/lib/ui/date_picker.js
@@ -1,0 +1,201 @@
+import '../utilities/dom_component.js'
+import './date_picker/calendar.js'
+
+Romo.define('Romo.UI.DatePicker', function() {
+  return class extends Romo.DOMComponent {
+    constructor(dom) {
+      super(dom)
+
+      this._bind()
+    }
+
+    static get attrPrefix() {
+      return 'romo-ui-date-picker'
+    }
+
+    get formatString() {
+      return Romo.memoize(this, 'formatString', function() {
+        return this.domData('format') || Romo.config.datePicker.defaultFormatFn()
+      })
+    }
+
+    get romoDropdown() {
+      return Romo.memoize(this, 'romoDropdown', function() {
+        return this._bindDropdown()
+      })
+    }
+
+    get calendar() {
+      return Romo.memoize(this, 'calendar', function() {
+        return this._bindCalendar()
+      })
+    }
+
+    get dropdownPopoverBodyDOM() {
+      return this.romoDropdown.popoverBodyDOM
+    }
+
+    doSetValue(value) {
+      this.date = Romo.Date.parse(value)
+
+      if (this.date !== undefined) {
+        this.dom.firstElement.value =
+          Romo.Date.format(this.date, this.formatString)
+      } else {
+        this.dom.firstElement.value = value
+      }
+      this._triggerSetValueChangeEvent()
+
+      return this
+    }
+
+    // private
+
+    _bind() {
+      this.prevValue = this.dom.firstElement.value
+      this.doSetValue(this.prevValue)
+
+      this.on('change', this._onChange)
+      this.on('blur', this._onBlur)
+      this.on('keydown', this._onKeyDown)
+      this.on('Romo.UI.IndicatorTextInput:indicatorClicked', function(e) {
+        this.romoDropdown.doOpenPopover()
+      })
+      this.on('Romo.UI.Dropdown:popoverOpened', this._onPopoverOpened)
+
+      this._bindIndicatorTextInput()
+    }
+
+    _bindIndicatorTextInput() {
+      this.dom.setDataDefault(
+        'romo-ui-indicator-text-input-indicator-icon-name',
+        Romo.config.datePicker.defaultIndicatorIconNameFn(this),
+      )
+      this.dom.setDataDefault(
+        'romo-ui-indicator-text-input-indicator-icon-css-class',
+        Romo.config.datePicker.defaultIndicatorIconCSSClassFn(this),
+      )
+      this.dom.setDataDefault(
+        'romo-ui-indicator-text-input-indicator-position',
+        Romo.config.datePicker.defaultIndicatorPositionFn(this),
+      )
+      this.dom.setDataDefault(
+        'romo-ui-indicator-text-input-indicator-spacing-px',
+        Romo.config.datePicker.defaultIndicatorSpacingPxFn(this),
+      )
+      this.dom.setDataDefault(
+        'romo-ui-indicator-text-input-indicator-width-px',
+        Romo.config.datePicker.defaultIndicatorWidthPxFn(this),
+      )
+      this.dom.setDataDefault(
+        'romo-ui-indicator-text-input-indicator-spinner-size-px',
+        Romo.config.datePicker.defaultIndicatorSpinnerSizePxFn(this),
+      )
+
+      this.romoIndicatorTextInput = new Romo.UI.IndicatorTextInput(this.dom)
+    }
+
+    _bindDropdown() {
+      this.dom.setData('romo-ui-dropdown-disable-click-toggle', 'true')
+      this.dom.setData('romo-ui-xhr-disabled', 'true')
+      if (!this.dom.data('romo-ui-dropdown-popover-width')) {
+        this.dom.setData('romo-ui-dropdown-popover-width', 'element')
+      }
+      if (this.dom.width() < 175) {
+        this.dom.setData('romo-ui-dropdown-popover-width', '175px')
+      }
+
+      return new Romo.UI.Dropdown(this.dom)
+    }
+
+    _bindCalendar() {
+      const calendar =
+        new Romo.UI.DatePicker.Calendar(
+          this.dropdownPopoverBodyDOM,
+          { formatString: this.formatString }
+        )
+
+      this
+        .dropdownPopoverBodyDOM
+        .on('mousedown', Romo.bind(this._onMouseDown, this))
+        .on(
+          'Romo.UI.DatePicker.Calendar:dayClicked',
+          Romo.bind(this._onDayClicked, this)
+        )
+        .append(calendar.dom)
+
+      return calendar
+    }
+
+    _triggerSetValueChangeEvent() {
+      if (this.dom.firstElement.value !== this.prevValue) {
+        this.dom.trigger('change')
+      }
+    }
+
+    _onMouseDown(e) {
+      e.preventDefault()
+      this._clearBlurTimeout()
+    }
+
+    _onDayClicked(e, dayValue) {
+      this.doSetValue(dayValue)
+      this.dom.firstElement.focus()
+      this.romoDropdown.doClosePopover()
+
+      this.domTrigger('daySelected', [dayValue])
+      if (dayValue !== this.prevValue) {
+        this.domTrigger('newDaySelected', [dayValue])
+      }
+      // Always publish the selected events before publishing any
+      // change events.
+      this._triggerSetValueChangeEvent()
+    }
+
+    _onChange(e) {
+      const newValue = this.dom.firstElement.value
+      this.domTrigger('changed', [this.prevValue, newValue])
+      this.prevValue = newValue
+    }
+
+    _onBlur(e) {
+      this._blurTimeoutID =
+        setTimeout(Romo.bind(function() {
+          this.romoDropdown.doClosePopover()
+        }, this), 10)
+    }
+
+    _clearBlurTimeout() {
+      if (this._blurTimeoutId !== undefined) {
+        clearTimeout(this._blurTimeoutId)
+        this._blurTimeoutId = undefined
+      }
+    }
+
+    _onKeyDown(e) {
+      if (this.dom.hasClass('disabled') === false) {
+        if (this.romoDropdown.isPopoverOpen) {
+          return true
+        } else {
+          if (e.keyCode === 40 /* Down */) {
+            this.romoDropdown.doOpenPopover()
+            return false
+          } else {
+            return true
+          }
+        }
+      }
+
+      return true
+    }
+
+    _onPopoverOpened(e) {
+      this.doSetValue(this.dom.firstElement.value)
+      this.calendar.doSetSelectedDate(this.date).doRefresh()
+      this.dropdownPopoverBodyDOM.firstElement.focus()
+      this._clearBlurTimeout()
+    }
+  }
+})
+
+Romo.addAutoInitSelector(`[data-${Romo.UI.DatePicker.attrPrefix}]`, Romo.UI.DatePicker)

--- a/lib/ui/date_picker/calendar.js
+++ b/lib/ui/date_picker/calendar.js
@@ -1,0 +1,144 @@
+import './calendar_body.js'
+
+Romo.define('Romo.UI.DatePicker.Calendar', function() {
+  return class {
+    constructor(popoverBodyDOM, { formatString } = {}) {
+      this.popoverBodyDOM = popoverBodyDOM
+      this.formatString = formatString
+
+      this.refreshDate = undefined
+      this.selectedDate = undefined
+      this._bind()
+    }
+
+    get dom() {
+      return Romo.memoize(this, 'dom', function() {
+        return Romo.dom(Romo.elements(this._tableTemplate))
+      })
+    }
+
+    get titleDOM() {
+      return Romo.memoize(this, 'titleDOM', function() {
+        return this.dom.find('[data-romo-ui-date-picker-calendar-title]')
+      })
+    }
+
+    get prevDOM() {
+      return Romo.memoize(this, 'prevDOM', function() {
+        return this.dom.find('[data-romo-ui-date-picker-calendar-prev]')
+      })
+    }
+
+    get nextDOM() {
+      return Romo.memoize(this, 'nextDOM', function() {
+        return this.dom.find('[data-romo-ui-date-picker-calendar-next]')
+      })
+    }
+
+    get bodyDOM() {
+      return this.dom.find('tbody')
+    }
+
+    get daysDOM() {
+      return this.bodyDOM.find('td')
+    }
+
+    doSetSelectedDate(date) {
+      this.selectedDate = date
+
+      return this
+    }
+
+    doRefresh(refreshDate) {
+      this.refreshDate = refreshDate || this.selectedDate || Romo.Date.today()
+
+      this.titleDOM.updateText(Romo.Date.format(this.refreshDate, 'MM yyyy'))
+      this._bindTableBody()
+
+      return this
+    }
+
+    doRefreshToPrevMonth() {
+      const pDate =
+        Romo.Date.lastDateOfPrevMonth(this.refreshDate || Romo.Date.today())
+      this.doRefresh(pDate)
+
+      return this
+    }
+
+    doRefreshToNextMonth() {
+      const nDate =
+        Romo.Date.firstDateOfNextMonth(this.refreshDate || Romo.Date.today())
+      this.doRefresh(nDate)
+
+      return this
+    }
+
+    // private
+
+    get _tableTemplate() {
+      return `
+<table class="romo-ui-date-picker-calendar">
+  <thead>
+    <tr>
+      <th title="Previous Month"
+          data-romo-ui-date-picker-calendar-prev>
+        ${Romo.config.datePicker.calendarPrevMonthMarkupFn()}
+      </th>
+      <th data-romo-ui-date-picker-calendar-title colspan="5"></th>
+      <th title="Next Month"
+          data-romo-ui-date-picker-calendar-next>
+        ${Romo.config.datePicker.calendarNextMonthMarkupFn()}
+      </th>
+    </tr>
+      <th>S</th>
+      <th>M</th>
+      <th>T</th>
+      <th>W</th>
+      <th>T</th>
+      <th>F</th>
+      <th>S</th>
+    <tr>
+    </tr>
+  </thead>
+  <tbody>
+  </tbody>
+</table>
+`
+    }
+
+    _bind() {
+      this.prevDOM.on('click', Romo.bind(function(e) {
+        e.preventDefault()
+        this.doRefreshToPrevMonth()
+      }, this))
+      this.nextDOM.on('click', Romo.bind(function(e) {
+        e.preventDefault()
+        this.doRefreshToNextMonth()
+      }, this))
+    }
+
+    _bindTableBody() {
+      const calendarBody =
+        new Romo.UI.DatePicker.CalendarBody(
+          this.refreshDate,
+          {
+            formatString:  this.formatString,
+            selectedDate:  this.selectedDate,
+            highlightDate: this.refreshDate,
+          }
+        )
+      this.bodyDOM.replace(calendarBody.dom)
+
+      this.daysDOM.on(
+        'Romo.UI.DatePicker.CalendarBody:dayClicked',
+        Romo.bind(function(e, dayValue) {
+          this.popoverBodyDOM.trigger(
+            'Romo.UI.DatePicker.Calendar:dayClicked',
+            [dayValue]
+          )
+        }, this)
+      )
+    }
+  }
+})

--- a/lib/ui/date_picker/calendar_body.js
+++ b/lib/ui/date_picker/calendar_body.js
@@ -1,0 +1,122 @@
+Romo.define('Romo.UI.DatePicker.CalendarBody', function() {
+  return class {
+    constructor(date, { formatString, selectedDate } = {}) {
+      this.today = Romo.Date.today()
+      this.date = date
+      this.formatString = formatString
+      this.selectedDate = selectedDate
+      this.highlightDate = this.date
+    }
+
+    get dom() {
+      return Romo.memoize(this, 'dom', function() {
+        return this._bindDOM()
+      })
+    }
+
+    get html() {
+      return Romo.memoize(this, 'html', function() {
+        return this._buildHTML()
+      })
+    }
+
+    // private
+
+    _bindDOM() {
+      const dom = Romo.dom(Romo.elements(this.html))
+
+      dom
+        .find('td:not(.disabled)')
+        .on('click', Romo.bind(this._onClick, this))
+        .on('mouseenter', Romo.bind(this._onMouseEnter, this))
+
+      return dom
+    }
+
+    _onClick(e) {
+      const tdDOM = Romo.dom(e.target).closest('td')
+      const value = tdDOM.data('romo-ui-date-picker-value')
+
+      this.dom.find('td').removeClass('selected')
+      tdDOM.addClass('selected')
+      tdDOM.trigger(
+        'Romo.UI.DatePicker.CalendarBody:dayClicked',
+        [value]
+      )
+    }
+
+    _onMouseEnter(e) {
+      this.dom.find('td').removeClass('highlight')
+      Romo.dom(e.target).closest('td').addClass('highlight')
+    }
+
+    _buildHTML() {
+      var html = []
+
+      // Prefer showing as many past dates in each month as possible by
+      // calculating the most post days we can show and still fit the date's
+      // month in 6 weeks of displayed days:
+      // - 7 days * 6 weeks = 42 displayed days
+      // - 42 displayed days - {days in month} = {max past days}
+
+      // first-of-month
+      const fom = Romo.Date.firstDateOfMonth(this.date)
+      // days-in-month
+      const dim = Romo.Date.daysInMonth(this.date)
+
+      // Start on this week's Sunday. if there is enough room, start on prev
+      // week's Sunday.
+      var past = fom.getDay()
+      if ((past + 7) <= (42 - dim)) {
+        past = past + 7
+      }
+      var iDate = Romo.Date.vector(fom, -past)
+
+      // Render 6 weeks in the calendar.
+      var iWeek = 0
+      while (iWeek < 6) {
+        if (Romo.Date.isDay(iDate, 'Sunday')) {
+          html.push('<tr>')
+        }
+
+        html.push(this._buildDayHTML(iDate))
+
+        if (Romo.Date.isDay(iDate, 'Saturday')) {
+          html.push('</tr>')
+          iWeek += 1
+        }
+        iDate = Romo.Date.next(iDate)
+      }
+
+      return `<tbody>${html.join('')}</tbody>`
+    }
+
+    _buildDayHTML(date) {
+      const value = Romo.Date.format(date, this.formatString)
+      var cssClasses = []
+      if (Romo.Date.isWeekend(date)) {
+        cssClasses.push('weekend')
+      }
+      if (!Romo.Date.isSameMonth(date, this.date)) {
+        cssClasses.push('other-month')
+      }
+      if (Romo.Date.isEqual(date, this.today)) {
+        cssClasses.push('today')
+      }
+      if (Romo.Date.isEqual(date, this.selectedDate)) {
+        cssClasses.push('selected')
+      }
+      if (Romo.Date.isEqual(date, this.highlightDate)) {
+        cssClasses.push('highlight')
+      }
+
+      return `
+<td class="${cssClasses.join(' ')}"
+    title="${value}"
+    data-romo-ui-date-picker-value="${value}">
+  ${Romo.Date.format(date, 'd')}
+</td>
+`
+    }
+  }
+})

--- a/lib/ui/indicator_text_input.js
+++ b/lib/ui/indicator_text_input.js
@@ -172,7 +172,7 @@ Romo.define('Romo.UI.IndicatorTextInput', function() {
 
       if (this.dom.disabled !== true) {
         this.dom.firstElement.focus()
-        this.dom.trigger('SC.IndicatorTextInput:indicatorClicked', [this])
+        this.domTrigger('indicatorClicked')
       }
     }
   }

--- a/test/system_tests.html
+++ b/test/system_tests.html
@@ -22,6 +22,7 @@
     <ul>
       <li><a href="./ui/avatar_tests.html">Romo.UI.Avatar</a></li>
       <li><a href="./ui/banner_tests.html">Romo.UI.Banner</a></li>
+      <li><a href="./ui/date_picker_tests.html">Romo.UI.DatePicker</a></li>
       <li><a href="./ui/form_tests.html">Romo.UI.Form</a></li>
       <li><a href="./ui/frame_tests.html">Romo.UI.Frame</a></li>
       <li><a href="./ui/indicator_text_input_tests.html">Romo.UI.IndicatorTextInput</a></li>
@@ -1568,6 +1569,9 @@
       })
       tests.test('<code>Romo.UI.Banner</code>', function(test) {
         test.assert(Romo.UI.Banner !== undefined)
+      })
+      tests.test('<code>Romo.UI.DatePicker</code>', function(test) {
+        test.assert(Romo.UI.DatePicker !== undefined)
       })
       tests.test('<code>Romo.UI.Dropdown</code>', function(test) {
         test.assert(Romo.UI.Dropdown !== undefined)

--- a/test/ui/date_picker_tests.html
+++ b/test/ui/date_picker_tests.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <link rel="stylesheet" type="text/css" href="/support/romo-js/romo-ui.css"/>
+  <style>
+    i {
+      font-style: normal;
+    }
+    i.i.check:before {
+      content: '\2705';
+    }
+  </style>
+</head>
+<body style="padding-top: 25px">
+  <h1>Romo.UI.DatePicker system tests</h1>
+  <h3>Examples</h3>
+
+  <p>Without specifying `data-romo-indicator-text-input-indicator-icon-name`, the date picker is placed in a wrapper but otherwise is unchanged:</p>
+  <div style="width: 350px">
+    <input type="text"
+           data-romo-ui-date-picker>
+  </div>
+
+  <p>Specify a `data-sc-indicator-text-input-indicator-icon-name` to add an indicator icon:</p>
+  <div style="width: 350px">
+    <input type="text"
+           data-romo-ui-date-picker
+           data-romo-ui-indicator-text-input-indicator-icon-css-class="i"
+           data-romo-ui-indicator-text-input-indicator-icon-name="check">
+  </div>
+</body>
+<script type="module" src="/support/romo-js/romo-ui.js"></script>
+<script type="module" src="/support/tests.js"></script>
+<script type="module">
+  Romo.onReady(function() {
+  })
+</script>


### PR DESCRIPTION
Mix this in on text inputs to add date picking behavior. A date
picker composes Romo.UI.IndicatorTextInput (to optionally render
a "calendar" or other indicator icon on the input) and composes
Romo.UI.Dropdown (to render popover calendar UI).

# Demo

![date-picker-1](https://user-images.githubusercontent.com/82110/108393917-c0b71d00-71d9-11eb-8686-e72687545c9a.gif)
