### PR TITLE
add keyboard navigation and open-on-focus support to Romo.UI.DatePicker

### DIFF
--- a/lib/ui/date_picker.js
+++ b/lib/ui/date_picker.js
@@ -119,8 +119,8 @@ Romo.define('Romo.UI.DatePicker', function() {
         .dropdownPopoverBodyDOM
         .on('mousedown', Romo.bind(this._onMouseDown, this))
         .on(
-          'Romo.UI.DatePicker.Calendar:dayClicked',
-          Romo.bind(this._onDayClicked, this)
+          'Romo.UI.DatePicker.Calendar:daySelected',
+          Romo.bind(this._onDaySelected, this)
         )
       this.romoDropdown.doUpdatePopoverBodyDOM(calendar.dom)
 
@@ -138,14 +138,16 @@ Romo.define('Romo.UI.DatePicker', function() {
       this._clearBlurTimeout()
     }
 
-    _onDayClicked(e, dayValue) {
+    _onDaySelected(e, dayDOM) {
+      const dayValue = dayDOM.data('romo-ui-date-picker-value')
+
       this.doSetValue(dayValue)
       this.dom.firstElement.focus()
       this.romoDropdown.doClosePopover()
 
-      this.domTrigger('daySelected', [dayValue])
+      this.domTrigger('daySelected', [dayValue, dayDOM])
       if (dayValue !== this.prevValue) {
-        this.domTrigger('newDaySelected', [dayValue])
+        this.domTrigger('newDaySelected', [dayValue, dayDOM])
       }
       // Always publish the selected events before publishing any
       // change events.
@@ -175,18 +177,41 @@ Romo.define('Romo.UI.DatePicker', function() {
     _onKeyDown(e) {
       if (this.dom.hasClass('disabled') === false) {
         if (this.romoDropdown.isPopoverOpen) {
-          return true
+          this._onPopoverOpenedKeyDown(e)
         } else {
-          if (e.keyCode === 40 /* Down */) {
-            this.romoDropdown.doOpenPopover()
-            return false
-          } else {
-            return true
-          }
+          this._onPopoverClosedKeyDown(e)
         }
       }
+    }
 
-      return true
+    _onPopoverOpenedKeyDown(e) {
+      e.stopPropagation()
+
+      if (e.keyCode === 38 /* Up */) {
+        e.preventDefault()
+        this.calendar.doHighlightPrevWeekDay()
+      } else if (e.keyCode === 40 /* Down */) {
+        e.preventDefault()
+        this.calendar.doHighlightNextWeekDay()
+      } else if (e.keyCode === 37 /* Left */) {
+        e.preventDefault()
+        this.calendar.doHighlightPrevDay()
+      } else if (e.keyCode === 39 /* Right */) {
+        e.preventDefault()
+        this.calendar.doHighlightNextDay()
+      } else if (e.keyCode === 13 /* Enter */) {
+        e.preventDefault()
+        this.calendar.doSelectHighlightDay()
+      }
+    }
+
+    _onPopoverClosedKeyDown(e) {
+      if (e.keyCode === 40 /* Down */ || e.keyCode === 38 /* Up */) {
+        e.stopPropagation()
+        e.preventDefault()
+
+        this.romoDropdown.doOpenPopover()
+      }
     }
 
     _onPopoverOpened(e) {

--- a/lib/ui/date_picker.js
+++ b/lib/ui/date_picker.js
@@ -35,6 +35,10 @@ Romo.define('Romo.UI.DatePicker', function() {
       return this.romoDropdown.popoverBodyDOM
     }
 
+    get shouldOpenOnFocus() {
+      return this.domData('open-on-focus')
+    }
+
     doSetValue(value) {
       this.date = Romo.Date.parse(value)
 
@@ -56,12 +60,14 @@ Romo.define('Romo.UI.DatePicker', function() {
       this.doSetValue(this.prevValue)
 
       this.on('change', this._onChange)
+      this.on('focus', this._onFocus)
       this.on('blur', this._onBlur)
       this.on('keydown', this._onKeyDown)
       this.on('Romo.UI.IndicatorTextInput:indicatorClicked', function(e) {
-        this.romoDropdown.doOpenPopover()
+        this._openPopover()
       })
       this.on('Romo.UI.Dropdown:popoverOpened', this._onPopoverOpened)
+      this.on('Romo.UI.Dropdown:popoverClosed', this._onPopoverClosed)
 
       this._bindIndicatorTextInput()
     }
@@ -133,6 +139,10 @@ Romo.define('Romo.UI.DatePicker', function() {
       }
     }
 
+    _openPopover() {
+      this.romoDropdown.doOpenPopover()
+    }
+
     _onMouseDown(e) {
       e.preventDefault()
       this._clearBlurTimeout()
@@ -160,10 +170,18 @@ Romo.define('Romo.UI.DatePicker', function() {
       this.prevValue = newValue
     }
 
+    _onFocus(e) {
+      if (this.shouldOpenOnFocus && !this.focusFromClosingThePopover) {
+        this._openPopover()
+      }
+      this.focusFromClosingThePopover = false
+    }
+
     _onBlur(e) {
       this._blurTimeoutID =
         setTimeout(Romo.bind(function() {
           this.romoDropdown.doClosePopover()
+          this.pushFn(function() { this.focusFromClosingThePopover = false })
         }, this), 10)
     }
 
@@ -210,15 +228,18 @@ Romo.define('Romo.UI.DatePicker', function() {
         e.stopPropagation()
         e.preventDefault()
 
-        this.romoDropdown.doOpenPopover()
+        this._openPopover()
       }
     }
 
     _onPopoverOpened(e) {
       this.doSetValue(this.dom.firstElement.value)
       this.calendar.doSetSelectedDate(this.date).doRefresh()
-      this.dropdownPopoverBodyDOM.firstElement.focus()
       this._clearBlurTimeout()
+    }
+
+    _onPopoverClosed(e) {
+      this.focusFromClosingThePopover = this.dom.hasFocus
     }
   }
 })

--- a/lib/ui/date_picker/calendar.js
+++ b/lib/ui/date_picker/calendar.js
@@ -43,6 +43,20 @@ Romo.define('Romo.UI.DatePicker.Calendar', function() {
       return this.bodyDOM.find('td')
     }
 
+    get highlightDayDOM() {
+      return this.bodyDOM.find('td.highlight')
+    }
+
+    get highlightDayValue() {
+      return this.highlightDayDOM.data('romo-ui-date-picker-value')
+    }
+
+    dayDOM(dayValue) {
+      return (
+        this.bodyDOM.find(`td[data-romo-ui-date-picker-value="${dayValue}"]`)
+      )
+    }
+
     doSetSelectedDate(date) {
       this.selectedDate = date
 
@@ -70,6 +84,84 @@ Romo.define('Romo.UI.DatePicker.Calendar', function() {
       const nDate =
         Romo.Date.firstDateOfNextMonth(this.refreshDate || Romo.Date.today())
       this.doRefresh(nDate)
+
+      return this
+    }
+
+    doHighlightPrevWeekDay() {
+      this.doHighlightPrevDay(
+        Romo.Date.vector(Romo.Date.parse(this.highlightDayValue), -6)
+      )
+
+      return this
+    }
+
+    doHighlightNextWeekDay() {
+      this.doHighlightNextDay(
+        Romo.Date.vector(Romo.Date.parse(this.highlightDayValue), 6)
+      )
+
+      return this
+    }
+
+    doHighlightPrevDay(fromDate) {
+      var iDate = fromDate || Romo.Date.parse(this.highlightDayValue)
+      var dayDOM
+
+      do {
+        iDate = Romo.Date.vector(iDate, -1)
+        dayDOM = this.dayDOM(Romo.Date.format(iDate, this.formatString))
+
+        if (!dayDOM.hasElements) {
+          this.doRefresh(iDate)
+          dayDOM = this.dayDOM(Romo.Date.format(iDate, this.formatString))
+        }
+      } while (dayDOM.hasClass('.disabled'))
+
+      this.doHighlightDay(dayDOM)
+
+      return this
+    }
+
+    doHighlightNextDay(fromDate) {
+      var iDate = fromDate || Romo.Date.parse(this.highlightDayValue)
+      var dayDOM
+
+      do {
+        iDate = Romo.Date.vector(iDate, 1)
+        dayDOM = this.dayDOM(Romo.Date.format(iDate, this.formatString))
+
+        if (!dayDOM.hasElements) {
+          this.doRefresh(iDate)
+          dayDOM = this.dayDOM(Romo.Date.format(iDate, this.formatString))
+        }
+      } while (dayDOM.hasClass('.disabled'))
+
+      this.doHighlightDay(dayDOM)
+
+      return this
+    }
+
+    doHighlightDay(dayDOM) {
+      this.highlightDayDOM.removeClass('highlight')
+      dayDOM.addClass('highlight')
+
+      return this
+    }
+
+    doSelectHighlightDay() {
+      this.doSelectDay(this.highlightDayDOM)
+
+      return this
+    }
+
+    doSelectDay(dayDOM) {
+      if (dayDOM) {
+        this.popoverBodyDOM.trigger(
+          'Romo.UI.DatePicker.Calendar:daySelected',
+          [dayDOM]
+        )
+      }
 
       return this
     }
@@ -132,11 +224,8 @@ Romo.define('Romo.UI.DatePicker.Calendar', function() {
 
       this.daysDOM.on(
         'Romo.UI.DatePicker.CalendarBody:dayClicked',
-        Romo.bind(function(e, dayValue) {
-          this.popoverBodyDOM.trigger(
-            'Romo.UI.DatePicker.Calendar:dayClicked',
-            [dayValue]
-          )
+        Romo.bind(function(e, dayDOM) {
+          this.doSelectDay(dayDOM)
         }, this)
       )
     }

--- a/lib/ui/date_picker/calendar_body.js
+++ b/lib/ui/date_picker/calendar_body.js
@@ -35,13 +35,11 @@ Romo.define('Romo.UI.DatePicker.CalendarBody', function() {
 
     _onClick(e) {
       const tdDOM = Romo.dom(e.target).closest('td')
-      const value = tdDOM.data('romo-ui-date-picker-value')
-
       this.dom.find('td').removeClass('selected')
       tdDOM.addClass('selected')
       tdDOM.trigger(
         'Romo.UI.DatePicker.CalendarBody:dayClicked',
-        [value]
+        [tdDOM]
       )
     }
 

--- a/lib/utilities/dom.js
+++ b/lib/utilities/dom.js
@@ -22,6 +22,14 @@ Romo.define('Romo.DOM', function() {
       return this.length !== 0
     }
 
+    get isActive() {
+      return this.firstElement === document.activeElement
+    }
+
+    get hasFocus() {
+      return this.is(':focus')
+    }
+
     get length() {
       return this.elements.length
     }

--- a/test/ui/date_picker_tests.html
+++ b/test/ui/date_picker_tests.html
@@ -33,5 +33,6 @@
 <script type="module" src="/support/tests.js"></script>
 <script type="module">
   Romo.onReady(function() {
+    Romo.f('[data-romo-ui-date-picker]').firstElement.focus()
   })
 </script>

--- a/test/ui/date_picker_tests.html
+++ b/test/ui/date_picker_tests.html
@@ -25,6 +25,7 @@
   <div style="width: 350px">
     <input type="text"
            data-romo-ui-date-picker
+           data-romo-ui-date-picker-open-on-focus="true"
            data-romo-ui-indicator-text-input-indicator-icon-css-class="i"
            data-romo-ui-indicator-text-input-indicator-icon-name="check">
   </div>


### PR DESCRIPTION
### add keyboard navigation to Romo.UI.DatePicker

This is inspired by the keyboard navigation used in the Select
Dropdown component. The DatePicker is basically a select dropdown
bound to an indicator text input that uses a calendar layout for
the selection UI. Therefore it is reasonable to expect to use the
keyboard to highlight and select date values like you would in
a select dropdown.

This adds the behavior and limits the keyboard navigation to only
be in effect when the calendar dropdown is open.

### add open-on-focus support to Romo.UI.DatePicker

This is also inspired by the same feature on Romo.UI.SelectDropdown
and behaves similarly. This should be an expected configuration
option for all Romo JS form input component mixins.

# Demo

Keyboard navigation:
![date-picker-keyboard-1](https://user-images.githubusercontent.com/82110/108634691-5ce25d80-7440-11eb-9418-bf1eb187b9c6.gif)

Open on focus:
![date-picker-open-on-focus-1](https://user-images.githubusercontent.com/82110/108634694-6075e480-7440-11eb-8907-6391449a1e93.gif)

