### PR TITLE
support ad-hoc option data-properties on SelectDropdown options

### DIFF
--- a/lib/ui/indicator_text_input.css
+++ b/lib/ui/indicator_text_input.css
@@ -13,6 +13,10 @@
   display: inline-block;
   position: absolute;
   top: 0;
+}
+
+[data-romo-ui-indicator-text-input-indicator] > * {
+  display: inline-block;
   vertical-align: middle;
 }
 

--- a/lib/ui/select_dropdown.css
+++ b/lib/ui/select_dropdown.css
@@ -8,6 +8,11 @@
   --romo-ui-select-dropdown-in-optgroup-option-left-padding: 1rem;
 }
 
+[data-romo-ui-select-dropdown-container] {
+  background-color: var(--romo-ui-select-dropdown-background-color);
+  color: var(--romo-ui-select-dropdown-color);
+}
+
 [data-romo-ui-select-dropdown-filter-container] {
   padding: 4px;
   border: 1px solid var(--romo-ui-select-dropdown-filter-container-border-color);
@@ -22,6 +27,7 @@
   list-style: none;
   margin: 0;
   padding: 0;
+  user-select: none;
 }
 
 [data-romo-ui-select-dropdown-options-list] li.option,
@@ -34,12 +40,12 @@
 }
 
 [data-romo-ui-select-dropdown-options-list] li.option.highlight {
-  background-color: var(--romo-ui-date-picker-calendar-highlight-background-color) !important;
-  color: var(--romo-ui-date-picker-calendar-highlight-day-color) !important;
+  background-color: var(--romo-ui-select-dropdown-highlight-option-background-color) !important;
+  color: var(--romo-ui-select-dropdown-highlight-option-color) !important;
 }
 
 [data-romo-ui-select-dropdown-options-list] li.option.disabled {
-  color: var(--romo-ui-date-picker-calendar-disabled-day-color);
+  color: var(--romo-ui-select-dropdown-disabled-option-color);
   cursor: not-allowed;
 }
 

--- a/lib/ui/select_dropdown.js
+++ b/lib/ui/select_dropdown.js
@@ -167,7 +167,7 @@ Romo.define('Romo.UI.SelectDropdown', function() {
 
     _onPopoverOpened(e) {
       this.doSetValue(this.value)
-      this.container.doSetSelectedValue(this.value).doRefresh()
+      this.container.doSetSelectedValue(this.value).doRefresh().doLockWidth()
       if (this._popoverOpenedCallbackFn) {
         this._popoverOpenedCallbackFn()
         this._popoverOpenedCallbackFn = undefined
@@ -177,7 +177,7 @@ Romo.define('Romo.UI.SelectDropdown', function() {
     _onPopoverClosed(e) {
       this.focusFromClosingThePopover = true
       this.dom.firstElement.focus()
-      this.container.optionsDOM.removeClass('highlight').removeClass('hidden')
+      this.container.doResetOptionsDOM().doUnlockWidth()
     }
   }
 })

--- a/lib/ui/select_dropdown.js
+++ b/lib/ui/select_dropdown.js
@@ -102,7 +102,7 @@ Romo.define('Romo.UI.SelectDropdown', function() {
     }
 
     _onOptionSelected(e, optionDOM) {
-      const optionValue = optionDOM.data('romo-ui-select-dropdown-value')
+      const optionValue = optionDOM.data('option-value')
       this.doSetValue(optionValue)
       this.romoDropdown.doClosePopover()
 

--- a/lib/ui/select_dropdown/container.js
+++ b/lib/ui/select_dropdown/container.js
@@ -88,6 +88,27 @@ Romo.define('Romo.UI.SelectDropdown.Container', function() {
       return this
     }
 
+    doResetOptionsDOM() {
+      this.optionsDOM.removeClass('highlight').removeClass('hidden')
+
+      return this
+    }
+
+    doLockWidth() {
+      this.popoverContentDOM.setStyle(
+        'width',
+        `${this.popoverContentDOM.width()}px`
+      )
+
+      return this
+    }
+
+    doUnlockWidth() {
+      this.popoverContentDOM.rmStyle('width')
+
+      return this
+    }
+
     doHighlightPrevOption() {
       var prevOptionDOM = this.highlightPrevOptionDOM
       if (!prevOptionDOM.hasElements) {

--- a/lib/ui/select_dropdown/options_list.js
+++ b/lib/ui/select_dropdown/options_list.js
@@ -93,9 +93,17 @@ Romo.define('Romo.UI.SelectDropdown.OptionsList', function() {
       if (option.disabled) {
         cssClasses.push('disabled')
       }
+
+      const dataPropertiesHTML =
+        Object
+          .keys(option)
+          .map(function(key) {
+            return `data-option-${key}="${option[key]}"`
+          })
+          .join(' ')
+
       return `
-<li class="${cssClasses.join(' ')}"
-    data-romo-ui-select-dropdown-value="${option.value}">
+<li class="${cssClasses.join(' ')}" ${dataPropertiesHTML}>
   ${option.label || option.value}
 </li>
 `


### PR DESCRIPTION
This allows the user to specify custom properties that can be
retrieved on selected options from the yielded DOM object.
# Other Changes

### lock the Romo.UI.SelectDropdown width on open; unlock on close

This means that the width won't change while you filter options
and remove wider options as you filter.
