### PR TITLE
add filtering flexibility to Romo.UI.SelectDropdown

### DIFF
--- a/lib/ui/indicator_text_input/indicator.js
+++ b/lib/ui/indicator_text_input/indicator.js
@@ -94,7 +94,7 @@ Romo.define('Romo.UI.IndicatorTextInput.Indicator', function() {
         }
 
         if (this.indicatorTextInputDOM.css('display') === 'none') {
-          this.DOM.hide()
+          this.dom.hide()
         }
 
         const spacingPx = parseInt(this.spacingPx, 10)

--- a/lib/ui/select_dropdown.js
+++ b/lib/ui/select_dropdown.js
@@ -33,6 +33,22 @@ Romo.define('Romo.UI.SelectDropdown', function() {
       return this.romoDropdown.popoverBodyDOM
     }
 
+    get options() {
+      return this.domData('options-json')
+    }
+
+    set options(value) {
+      return this.setDOMData('options-json', JSON.stringify(value))
+    }
+
+    get isPopoverOpen() {
+      return this.romoDropdown.isOpen
+    }
+
+    get isPopoverClosed() {
+      return this.romoDropdown.isClosed
+    }
+
     get shouldOpenOnFocus() {
       return this.domData('open-on-focus')
     }
@@ -44,6 +60,12 @@ Romo.define('Romo.UI.SelectDropdown', function() {
     doSetValue(value) {
       this.value = value
       this._triggerSetValueChangeEvent()
+
+      return this
+    }
+
+    doUpdateOptions(options) {
+      this.options = options
 
       return this
     }
@@ -60,6 +82,10 @@ Romo.define('Romo.UI.SelectDropdown', function() {
       this.on('focus', this._onFocus)
       this.on('Romo.UI.Dropdown:popoverOpened', this._onPopoverOpened)
       this.on('Romo.UI.Dropdown:popoverClosed', this._onPopoverClosed)
+
+      this.domOn('triggerUpdateOptions', function(e, options) {
+        this.doUpdateOptions(options)
+      })
     }
 
     _bindDropdown() {
@@ -73,7 +99,7 @@ Romo.define('Romo.UI.SelectDropdown', function() {
       const container =
         new Romo.UI.SelectDropdown.Container(
           this.dropdownPopoverBodyDOM,
-          { options: this.domData('options-json') }
+          { options: this.options }
         )
 
       if (this.shouldShowFilter === false) {
@@ -174,6 +200,9 @@ Romo.define('Romo.UI.SelectDropdown', function() {
     }
 
     _onPopoverOpened(e) {
+      if (this.container.refreshOptions !== this.options) {
+        this.container.doUpdateAndRefreshOptions(this.options)
+      }
       this.doSetValue(this.value)
       this.container.doSetSelectedValue(this.value).doRefresh().doLockWidth()
       this.container.doBindWindowKeyDown()

--- a/lib/ui/select_dropdown.js
+++ b/lib/ui/select_dropdown.js
@@ -37,6 +37,10 @@ Romo.define('Romo.UI.SelectDropdown', function() {
       return this.domData('open-on-focus')
     }
 
+    get shouldShowFilter() {
+      return this.domData('show-filter')
+    }
+
     doSetValue(value) {
       this.value = value
       this._triggerSetValueChangeEvent()
@@ -71,6 +75,10 @@ Romo.define('Romo.UI.SelectDropdown', function() {
           this.dropdownPopoverBodyDOM,
           { options: this.domData('options-json') }
         )
+
+      if (this.shouldShowFilter === false) {
+        container.doHideFilter()
+      }
 
       this.dropdownPopoverBodyDOM.on(
         'Romo.UI.SelectDropdown.Container:optionSelected',
@@ -168,6 +176,7 @@ Romo.define('Romo.UI.SelectDropdown', function() {
     _onPopoverOpened(e) {
       this.doSetValue(this.value)
       this.container.doSetSelectedValue(this.value).doRefresh().doLockWidth()
+      this.container.doBindWindowKeyDown()
       if (this._popoverOpenedCallbackFn) {
         this._popoverOpenedCallbackFn()
         this._popoverOpenedCallbackFn = undefined
@@ -177,6 +186,7 @@ Romo.define('Romo.UI.SelectDropdown', function() {
     _onPopoverClosed(e) {
       this.focusFromClosingThePopover = true
       this.dom.firstElement.focus()
+      this.container.doUnBindWindowKeyDown()
       this.container.doResetOptionsDOM().doUnlockWidth()
     }
   }

--- a/lib/ui/select_dropdown/container.js
+++ b/lib/ui/select_dropdown/container.js
@@ -109,6 +109,18 @@ Romo.define('Romo.UI.SelectDropdown.Container', function() {
       return this
     }
 
+    doHideFilter() {
+      this.filterContainerDOM.hide()
+
+      return this
+    }
+
+    doShowFilter() {
+      this.filterContainerDOM.show()
+
+      return this
+    }
+
     doHighlightPrevOption() {
       var prevOptionDOM = this.highlightPrevOptionDOM
       if (!prevOptionDOM.hasElements) {
@@ -238,6 +250,18 @@ Romo.define('Romo.UI.SelectDropdown.Container', function() {
       return this
     }
 
+    doBindWindowKeyDown() {
+      Romo.dom(window).on('keydown', Romo.bind(this._onWindowKeyDown, this))
+
+      return this
+    }
+
+    doUnBindWindowKeyDown() {
+      Romo.dom(window).off('keydown', Romo.bind(this._onWindowKeyDown, this))
+
+      return this
+    }
+
     // private
 
     get _containerTemplate() {
@@ -259,8 +283,6 @@ Romo.define('Romo.UI.SelectDropdown.Container', function() {
 
     _bind() {
       this._bindFilter()
-
-      this.dom.on('keydown', Romo.bind(this._onKeyDown, this))
     }
 
     _bindFilter() {
@@ -315,7 +337,7 @@ Romo.define('Romo.UI.SelectDropdown.Container', function() {
       )
     }
 
-    _onKeyDown(e) {
+    _onWindowKeyDown(e) {
       e.stopPropagation()
 
       if (e.keyCode === 38 /* Up */) {

--- a/lib/ui/select_dropdown/container.js
+++ b/lib/ui/select_dropdown/container.js
@@ -88,6 +88,12 @@ Romo.define('Romo.UI.SelectDropdown.Container', function() {
       return this
     }
 
+    doUpdateAndRefreshOptions(options) {
+      this.doUpdateOptions(options).doRefresh()
+
+      return this
+    }
+
     doResetOptionsDOM() {
       this.optionsDOM.removeClass('highlight').removeClass('hidden')
 

--- a/test/ui/select_dropdown_tests.html
+++ b/test/ui/select_dropdown_tests.html
@@ -21,8 +21,13 @@
     <button data-romo-ui-select-dropdown
             data-romo-ui-select-dropdown-options-json='[{"value": "Red"}, {"value": "Green"}, {"value": "Blue"}]'
             data-romo-ui-dropdown-popover-width="element"
-            data-romo-ui-dropdown-popover-min-width="150px">
+            data-romo-ui-dropdown-popover-min-width="150px"
+            data-update-options-receiver>
       Choose a Color
+    </button>
+    <button data-update-options-button
+            data-update-options-button-options-json='[{"value": "Orange"}, {"value": "Yellow"}, {"value": "Violet"}]'>
+      Update Options
     </button>
   </div>
 
@@ -99,5 +104,17 @@
       )
       .firstElement
       .focus()
+
+    Romo
+      .f('button[data-update-options-button]')
+      .on('click', function(e) {
+        var dom = Romo.dom(e.target)
+        var receiverDOM = dom.prev('button')
+
+        receiverDOM.trigger(
+          'Romo.UI.SelectDropdown:triggerUpdateOptions',
+          [dom.data('update-options-button-options-json')]
+        )
+      })
   })
 </script>

--- a/test/ui/select_dropdown_tests.html
+++ b/test/ui/select_dropdown_tests.html
@@ -26,6 +26,18 @@
     </button>
   </div>
 
+  <p>non-grouped, filter hidden</p>
+  <div style="width: 350px">
+    <div></div>
+    <button data-romo-ui-select-dropdown
+            data-romo-ui-select-dropdown-options-json='[{"value": "Red"}, {"value": "Green"}, {"value": "Blue"}]'
+            data-romo-ui-select-dropdown-show-filter="false"
+            data-romo-ui-dropdown-popover-width="element"
+            data-romo-ui-dropdown-popover-min-width="150px">
+      Choose a Color
+    </button>
+  </div>
+
   <p>non-grouped with disabled options</p>
   <div style="width: 350px">
     <div>Blue</div>


### PR DESCRIPTION
These commits not only make the API and usage more flexible for more scenarios but this is also prep for building out a picker component.

### add `data-romo-ui-select-dropdown-show-filter="false"` option

This allows configuring select dropdowns to not use a filter
input in the dropdown markup. This is just extra flexibility
for consumers of the component.

Note: I had to switch to binding on the window for the keydown
events for navigating options. This is b/c when the filter input
is hidden it can't receive key events. This is good b/c it
implicitly disables filtering the options. But it was bad b/c the
keydown events it normally received would propagate to the
container DOM and stopped propagating.

### update SelectDropdown to allow ad-hoc option updates

This allows for dynamically changing the options shown in a
dropdown and expands/enriches the API to allow for greater
flexibility.

# Demo

![select-dropdown-1](https://user-images.githubusercontent.com/82110/115904934-02a74e00-a42b-11eb-80b5-22cb58116d1f.gif)
