### PR TITLE
actually update SelectDropdown options when the dropdown is open

### DIFF
--- a/lib/api/dom_query.js
+++ b/lib/api/dom_query.js
@@ -161,8 +161,8 @@ Romo.siblings =
 
 Romo.prev =
   function(fromElement, selector) {
-    const prevElement =
-      Romo.dom(fromElement).firstElement.previousElementSibling
+    const currentElement = Romo.dom(fromElement).firstElement
+    const prevElement = currentElement && currentElement.previousElementSibling
 
     if (!prevElement || !selector || Romo.is(prevElement, selector)) {
       return prevElement
@@ -173,7 +173,8 @@ Romo.prev =
 
 Romo.next =
   function(fromElement, selector) {
-    const nextElement = Romo.dom(fromElement).firstElement.nextElementSibling
+    const currentElement = Romo.dom(fromElement).firstElement
+    const nextElement = currentElement && currentElement.nextElementSibling
 
     if (!nextElement || !selector || Romo.is(nextElement, selector)) {
       return nextElement

--- a/lib/ui/select_dropdown.js
+++ b/lib/ui/select_dropdown.js
@@ -42,11 +42,11 @@ Romo.define('Romo.UI.SelectDropdown', function() {
     }
 
     get isPopoverOpen() {
-      return this.romoDropdown.isOpen
+      return this.romoDropdown.isPopoverOpen
     }
 
     get isPopoverClosed() {
-      return this.romoDropdown.isClosed
+      return this.romoDropdown.isPopoverClosed
     }
 
     get shouldOpenOnFocus() {
@@ -66,6 +66,10 @@ Romo.define('Romo.UI.SelectDropdown', function() {
 
     doUpdateOptions(options) {
       this.options = options
+
+      if (this.isPopoverOpen) {
+        this.container.doUpdateAndRefreshOptions(this.options)
+      }
 
       return this
     }

--- a/lib/ui/select_dropdown/options_list.js
+++ b/lib/ui/select_dropdown/options_list.js
@@ -10,7 +10,7 @@ Romo.define('Romo.UI.SelectDropdown.OptionsList', function() {
 
       this.options = options
       this.selectedValue = selectedValue
-      this.highlightValue = selectedValue || options[0].value
+      this.highlightValue = selectedValue || (options[0] && options[0].value)
     }
 
     get dom() {

--- a/test/ui/select_dropdown_tests.html
+++ b/test/ui/select_dropdown_tests.html
@@ -15,6 +15,19 @@
   <h1>Romo.UI.SelectDropdown system tests</h1>
   <h3>Examples</h3>
 
+
+  <p>no options</p>
+  <div style="width: 350px">
+    <div></div>
+    <button data-romo-ui-select-dropdown
+            data-romo-ui-select-dropdown-options-json='[]'
+            data-romo-ui-dropdown-popover-width="element"
+            data-romo-ui-dropdown-popover-min-width="150px"
+            data-update-options-receiver>
+      Choose a Color
+    </button>
+  </div>
+
   <p>non-grouped</p>
   <div style="width: 350px">
     <div></div>

--- a/test/ui/select_dropdown_tests.html
+++ b/test/ui/select_dropdown_tests.html
@@ -92,6 +92,19 @@
       Choose a Color or Shape
     </button>
   </div>
+
+  <p>input picker</p>
+  <div style="width: 350px">
+    <input type="text"
+           placeholder="type to filter options"
+           data-input-picker
+           data-romo-ui-select-dropdown
+           data-romo-ui-select-dropdown-show-filter="false"
+           data-romo-ui-select-dropdown-options-json='[{"value": "red", "label": "Red", "groupLabel": "Colors"}, {"value": "orange", "label": "Orange", "groupLabel": "Colors"}, {"value": "yellow", "label": "Yellow", "groupLabel": "Colors"}, {"value": "green", "label": "Green", "groupLabel": "Colors"}, {"value": "blue", "label": "Blue", "groupLabel": "Colors"}, {"value": "indigo", "label": "Indigo", "groupLabel": "Colors"}, {"value": "violet", "label": "Violet", "groupLabel": "Colors"}, {"value": "circle", "label": "Circle", "groupLabel": "Shapes"}, {"value": "square", "label": "Square", "groupLabel": "Shapes"}, {"value": "triangle", "label": "Triangle", "groupLabel": "Shapes"}]'
+           data-romo-ui-dropdown-popover-width="element"
+           data-romo-ui-dropdown-popover-min-width="150px"
+           data-romo-ui-on-key>
+  </div>
 </body>
 <script type="module" src="/support/romo-js/romo-ui.js"></script>
 <script type="module" src="/support/tests.js"></script>
@@ -128,6 +141,23 @@
           'Romo.UI.SelectDropdown:triggerUpdateOptions',
           [dom.data('update-options-button-options-json')]
         )
+      })
+
+    const inputPickerDOM = Romo.f('input[data-input-picker]')
+    var allInputPickerOptions = inputPickerDOM.data('romo-ui-select-dropdown-options-json')
+    inputPickerDOM
+      .on('Romo.UI.OnKey:keyEvent', function(e, romoOnKey, keyEvent) {
+        if (
+          Romo.env.isInputKey(keyEvent.keyCode) &&
+          keyEvent.keyCode !== 13 /* Enter */ &&
+          keyEvent.metaKey === false
+        ) {
+          const matchingOptions =
+            allInputPickerOptions.filter(function(option) {
+              return option.label.includes(inputPickerDOM.firstElement.value)
+            })
+          inputPickerDOM.trigger('Romo.UI.SelectDropdown:triggerUpdateOptions', [matchingOptions])
+        }
       })
   })
 </script>


### PR DESCRIPTION

Previously, the only way to update the option list UI was to
close and reopen the dropdown. This is b/c we only updated the
options when the dropdown was opened. If is was already opened,
we just stored the new options but didn't try and update the list
UI.

This switches to, in addition to storing the new options, if the
dropdown is open also updating the list UI.

I didn't test thoroughly enough on previous iterations to this
logic. This adds a more thorough "input picker" test case to the
tests as well.

While working this, I noticed a bug in the `isPopover{Open|Closed}`
functions that I fix here too.

# Other Changes

### update SelectDropdown to not error when no options are specified

I missed this in the original testing and didn't consider this
case. This adds a test for it and fixes the bug.

### prevent errors getting prev/next DOM elements when there is no current element

This can randomly come up in unexpected situations. E.g. you can
have an empty DOM object that you call prev/next on. Instead of
hard erroring, prefer just behaving as if there isn't a prev/next
element.

I noticed this while testing out the SelectDropdown component
in an input picker scenario.

# Demo

![select-dropdown-2](https://user-images.githubusercontent.com/82110/116141360-2f16d080-a69e-11eb-8996-a9d56f986744.gif)
