### PR TITLE
fix a bug in Romo.UI.Form event submissions

### DIFF
--- a/lib/ui/form/event_submission.js
+++ b/lib/ui/form/event_submission.js
@@ -20,7 +20,7 @@ Romo.define('Romo.UI.Form.EventSubmission', function() {
           'Romo.UI.Form.Submission:eventSubmit',
           [Romo.UI.Form.Values.dataSet(this.formDOM, { includeFiles: true })]
         )
-        this.pushFn(this.doCompleteSubmit)
+        Romo.pushFn(Romo.bind(this.doCompleteSubmit, this))
       })
     }
   }

--- a/test/ui/form_tests.html
+++ b/test/ui/form_tests.html
@@ -34,6 +34,17 @@
             data-romo-ui-spinner>Submit (won't redirect page by default)</button>
   </form>
 
+  <form method="get"
+        accept-charset="UTF-8"
+        data-romo-ui-form
+        data-romo-ui-form-event-submit="true"
+        data-romo-ui-form-disable-focus-on-init="true">
+    <input type="text" name="value" value="thing / something"
+           placeholder="Enter a value.">
+    <button type="submit"
+            data-romo-ui-spinner>Event Submit</button>
+  </form>
+
   <div data-form-status>
   </div>
 </body>


### PR DESCRIPTION
I messed up the `pushFn` API in this instance. This also adds some
formal event submissions tests that I used to verify the bug
fix.

# Demo

![imagezeb6x](https://user-images.githubusercontent.com/82110/116302344-a9ab2300-a766-11eb-9490-c223f9b4e948.jpg)
