### PR TITLE
fix a bug with array Romo.URLSearchParams array value handling; add Romo.urlSearchURL

### DIFF
--- a/lib/api/xhr.js
+++ b/lib/api/xhr.js
@@ -15,3 +15,8 @@ Romo.urlSearch =
   function(...args) {
     return new Romo.URLSearchParams(...args).toString()
   }
+
+Romo.urlSearchURL =
+  function(...args) {
+    return new Romo.URLSearchParams(...args).toURL()
+  }

--- a/lib/utilities/url_search_params.js
+++ b/lib/utilities/url_search_params.js
@@ -77,9 +77,9 @@ Romo.define('Romo.URLSearchParams', function() {
       const combinedSearchParams =
         [givenURL.searchParams, this.urlSearchParams]
           .reduce(function(acc, searchParams) {
-            for (var key of searchParams.keys()) {
-              acc.append(key, searchParams.get(key))
-            }
+            searchParams.forEach(function(value, key) {
+              acc.append(key, value)
+            })
             return acc
           }, seedSearchParams)
 

--- a/test/system_tests.html
+++ b/test/system_tests.html
@@ -1193,14 +1193,28 @@
       tests.test('Given a blank Object', function(test) {
         test.assert(Romo.urlSearch() === "")
         test.assert(Romo.urlSearch({}) === "")
+
+        test.assert(Romo.urlSearchURL().toString() === window.location.toString())
+        test.assert(Romo.urlSearchURL({}).toString() === window.location.toString())
       })
 
       tests.test('Given a non-blank Object', function(test) {
         test.assert(Romo.urlSearch({ a: 2, b: 'three', c: 4 }) === "a=2&b=three&c=4")
-        test.assert(Romo.urlSearch({ a: 2, b: '', c: 4 }).toString() === "a=2&b=&c=4")
+        test.assert(Romo.urlSearch({ a: 2, b: '', c: 4 }) === "a=2&b=&c=4")
         test.assert(
-          Romo.urlSearch({ a: 2, b: '', c: 4 }, { removeBlanks: true }).toString() ===
+          Romo.urlSearch({ a: 2, b: '', c: 4 }, { removeBlanks: true }) ===
           "a=2&c=4"
+        )
+
+        test.assert(
+          Romo.urlSearchURL({ a: 2, b: 'three', c: 4 }).toString() === `${window.location.toString()}?a=2&b=three&c=4`
+        )
+        test.assert(
+          Romo.urlSearchURL({ a: 2, b: '', c: 4 }).toString() === `${window.location.toString()}?a=2&b=&c=4`
+        )
+        test.assert(
+          Romo.urlSearchURL({ a: 2, b: '', c: 4 }, { removeBlanks: true }).toString() ===
+          `${window.location.toString()}?a=2&c=4`
         )
       })
 
@@ -1212,6 +1226,23 @@
         test.assert(
           Romo.urlSearch({ "a[]": [''] }, { decode: true, removeBlanks: true }) ===
           ""
+        )
+
+        test.assert(
+          Romo.urlSearchURL({ a: [2, 3, 4] }, { decode: false }).toString() === `${window.location.toString()}?a=2%2C3%2C4`
+        )
+        test.assert(
+          Romo.urlSearchURL({ a: [2, 3, 4] }, { decode: true }).toString() === `${window.location.toString()}?a=2,3,4`
+        )
+        test.assert(
+          Romo.urlSearchURL({ "a[]": [2, 3, 4] }, { decode: true }).toString() === `${window.location.toString()}?a[]=2&a[]=3&a[]=4`
+        )
+        test.assert(
+          Romo.urlSearchURL({ "a[]": [''] }, { decode: true }).toString() === `${window.location.toString()}?a[]=`
+        )
+        test.assert(
+          Romo.urlSearchURL({ "a[]": [''] }, { decode: true, removeBlanks: true }).toString() ===
+          window.location.toString()
         )
       })
     })


### PR DESCRIPTION
There was a bug un the `.toURL` method of `Romo.URLSearchParams`
where, because we were using `.get()`, array params would only
ever return the first value in array params. This switches to
using `.forEach` instead of a for-loop on `.keys()` with `.get()`.
This is a more robust method for getting each key/value pair when
processing the search params.

This also adds a `Romo.urlSearchURL` API method to complement
`Romo.urlSearch`. This is mostly used to exercise the `.toURL`
method on `Romo.URLSearchParams` but is also available now for
convenience if needed.
