### PR TITLE
fix a bug in XHR POST Romo.UI.Form submissions

### DIFF
--- a/lib/ui/form/xhr_post_submission.js
+++ b/lib/ui/form/xhr_post_submission.js
@@ -7,7 +7,7 @@ Romo.define('Romo.UI.Form.XHRPostSubmission', function() {
     doStartSubmit() {
       return super.doStartSubmit({
         data:
-          Romo.UI.Form.Values.formData(this.formDOM, { includeFiles: true }),
+          Romo.UI.Form.Values.dataSet(this.formDOM, { includeFiles: true }),
         processData: false,
         contentType: false,
       })

--- a/lib/utilities/xml_http_request.js
+++ b/lib/utilities/xml_http_request.js
@@ -299,6 +299,7 @@ Romo.define('Romo.XMLHttpRequest.Data', function() {
             formData.append(name, value)
           })
         }
+        return formData
       })
     }
 

--- a/test/public/system_tests.html
+++ b/test/public/system_tests.html
@@ -1055,7 +1055,7 @@
         const lifecycleEvents = []
         const romoXHR =
           Romo.xhr({
-            url: 'https://api.github.com/repos/redding/romo-js?some=value',
+            url: '/api/xhr/info.json?some=value',
             data: {
               other: 'value'
             },
@@ -1108,7 +1108,7 @@
         test.fail()
 
         Romo.xhr({
-          url: 'https://api.github.com/repos/redding/romo-js?some=value',
+          url: '/api/xhr/info.json?some=value',
           data: {
             other: 'value'
           },
@@ -1140,7 +1140,7 @@
 
         Romo
           .xhr({
-            url: 'https://api.github.com/repos/redding/romo-js?some=value',
+            url: '/api/xhr/info.json?some=value',
             data: {
               other: 'value'
             },

--- a/test/public/ui/dropdowns/form/show.html
+++ b/test/public/ui/dropdowns/form/show.html
@@ -1,5 +1,5 @@
 <div style="padding: 10px">
-  <form action="https://api.github.com/repos/redding/romo-js"
+  <form action="/ui/forms/info.json?some=value"
         method="get"
         accept-charset="UTF-8"
         data-romo-ui-popover-form

--- a/test/public/ui/form_tests.html
+++ b/test/public/ui/form_tests.html
@@ -8,7 +8,7 @@
 <body style="padding-top: 25px">
   <h1>Romo.UI.Form system tests</h1>
 
-  <form action="https://api.github.com/repos/redding/romo-js"
+  <form action="/ui/forms/info.json"
         method="get"
         accept-charset="UTF-8"
         data-xhr-get-json-form
@@ -21,7 +21,7 @@
             data-romo-ui-spinner>Submit (redirects page)</button>
   </form>
 
-  <form action="https://api.github.com/repos/redding/romo-js"
+  <form action="/ui/forms/info.json"
         method="get"
         accept-charset="UTF-8"
         data-xhr-get-json-form

--- a/test/public/ui/form_tests.html
+++ b/test/public/ui/form_tests.html
@@ -8,6 +8,17 @@
 <body style="padding-top: 25px">
   <h1>Romo.UI.Form system tests</h1>
 
+  <form method="get"
+        accept-charset="UTF-8"
+        data-romo-ui-form
+        data-romo-ui-form-event-submit="true"
+        data-romo-ui-form-disable-focus-on-init="true">
+    <input type="text" name="value" value="thing / something"
+           placeholder="Enter a value.">
+    <button type="submit"
+            data-romo-ui-spinner>Event Submit</button>
+  </form>
+
   <form action="/ui/forms/info.json"
         method="get"
         accept-charset="UTF-8"
@@ -18,7 +29,7 @@
     <input type="text" name="value" value="thing / something"
            placeholder="Enter a value.">
     <button type="submit"
-            data-romo-ui-spinner>Submit (redirects page)</button>
+            data-romo-ui-spinner>Browser GET Submit (redirects page)</button>
   </form>
 
   <form action="/ui/forms/info.json"
@@ -31,18 +42,20 @@
     <input type="text" name="value" value="thing / something"
            placeholder="Enter a value.">
     <button type="submit"
-            data-romo-ui-spinner>Submit (won't redirect page by default)</button>
+            data-romo-ui-spinner>XHR GET Submit (won't redirect page by default)</button>
   </form>
 
-  <form method="get"
+  <form action="/ui/forms/resource"
+        method="post"
         accept-charset="UTF-8"
+        data-xhr-post-json-form
         data-romo-ui-form
-        data-romo-ui-form-event-submit="true"
+        data-romo-ui-form-xhr-response-type="json"
         data-romo-ui-form-disable-focus-on-init="true">
     <input type="text" name="value" value="thing / something"
            placeholder="Enter a value.">
     <button type="submit"
-            data-romo-ui-spinner>Event Submit</button>
+            data-romo-ui-spinner>XHR POST Submit</button>
   </form>
 
   <div data-form-status>

--- a/test/public/ui/modals/form/show.html
+++ b/test/public/ui/modals/form/show.html
@@ -5,7 +5,7 @@
           data-romo-ui-modal-popover-close>Close</button>
 </div>
 <div style="padding: 10px">
-  <form action="https://api.github.com/repos/redding/romo-js"
+  <form action="/ui/forms/info.json?some=value"
         method="get"
         accept-charset="UTF-8"
         data-romo-ui-popover-form>

--- a/test/public/ui/xhr_tests.html
+++ b/test/public/ui/xhr_tests.html
@@ -7,7 +7,7 @@
 </head>
 <body style="padding-top: 25px">
   <h1>Romo.UI.XHR system tests</h1>
-  <button href="https://api.github.com/repos/redding/romo-js"
+  <button href="/ui/xhr/info.json?some=value"
           data-romo-ui-xhr
           data-romo-ui-xhr-call-response-type="json">
     Example 1 (GET JSON via href)
@@ -15,35 +15,36 @@
   <br/><br/>
   <button data-romo-ui-xhr
           data-romo-ui-xhr-call-response-type="json"
-          data-romo-ui-xhr-call-url="https://api.github.com/repos/redding/romo-js">
+          data-romo-ui-xhr-call-url="/ui/xhr/info.json?some=value">
     Example 2 (GET JSON via data attr)
   </button>
   <br/><br/>
   <button data-romo-ui-xhr
           data-romo-ui-xhr-call-response-type="text"
-          data-romo-ui-xhr-call-url="https://api.github.com/repos/redding/romo-js">
+          data-romo-ui-xhr-call-url="/ui/xhr/info.json?some=value">
     Example 3 (text response type)
   </button>
   <br/><br/>
   <button data-romo-ui-xhr
           data-romo-ui-xhr-call-method="post"
           data-romo-ui-xhr-call-response-type="json"
-          data-romo-ui-xhr-call-url="https://api.github.com/repos/redding/romo-js">
-    Example 4 (POST, should fail)
+          data-romo-ui-xhr-call-url="/ui/xhr/resource?some=value">
+    Example 4 (POST)
   </button>
   <br/><br/>
   <button data-example-5-abort
           data-romo-ui-xhr
           data-romo-ui-xhr-call-response-type="json"
-          data-romo-ui-xhr-call-url="https://api.github.com/repos/redding/romo-js">
+          data-romo-ui-xhr-call-url="/ui/xhr/aborted.json">
     Example 5 (call, then abort)
   </button>
   <br/><br/>
   <button data-romo-ui-xhr
           data-romo-ui-xhr-call-on="underfined"
+          data-romo-ui-xhr-call-method="post"
           data-romo-ui-xhr-call-response-type="json"
-          data-romo-ui-xhr-call-url="https://api.github.com/repos/redding/romo-js">
-    Example 6 (clicking this does nothing)
+          data-romo-ui-xhr-call-url="/ui/xhr/resource?some=value">
+    Example 6 (POST, clicking this does nothing)
   </button>
   <button data-example-6-trigger-button>
     Trigger Example 6
@@ -52,21 +53,21 @@
   <button data-romo-ui-xhr
           data-romo-ui-xhr-call-only-once="true"
           data-romo-ui-xhr-call-response-type="json"
-          data-romo-ui-xhr-call-url="https://api.github.com/repos/redding/romo-js">
+          data-romo-ui-xhr-call-url="/ui/xhr/info.json?some=value">
     Example 7 (call only once)
   </button>
   <br/><br/>
   <button data-romo-ui-xhr
           data-romo-ui-xhr-confirm="Are you sure?"
           data-romo-ui-xhr-call-response-type="json"
-          data-romo-ui-xhr-call-url="https://api.github.com/repos/redding/romo-js">
+          data-romo-ui-xhr-call-url="/ui/xhr/info.json?some=value">
     Example 8 (with confirmation)
   </button>
   <br/><br/>
   <button data-romo-ui-xhr
           data-romo-ui-xhr-disable-with-spinner="true"
           data-romo-ui-xhr-call-response-type="json"
-          data-romo-ui-xhr-call-url="https://api.github.com/repos/redding/romo-js">
+          data-romo-ui-xhr-call-url="/ui/xhr/info.json?some=value">
     Example 9 (disable with spinner)
   </button>
   <button data-example-8-enable-button>
@@ -76,7 +77,7 @@
   <button data-romo-ui-xhr
           data-romo-ui-xhr-disabled="true"
           data-romo-ui-xhr-call-response-type="json"
-          data-romo-ui-xhr-call-url="https://api.github.com/repos/redding/romo-js">
+          data-romo-ui-xhr-call-url="/ui/xhr/info.json?some=value">
     Example 10 (disabled)
   </button>
   <br/><br/>
@@ -104,13 +105,13 @@
       })
       .on('Romo.UI.XHR:callSuccess', function(e, romoXHR, data, xhr) {
         statusDOM.appendHTML('<div>-> success</div>')
-        statusDOM.appendHTML(`<code>${data.toString()}</code>`)
+        statusDOM.appendHTML(`<code>${JSON.stringify(data)}</code>`)
         console.log('-> success, data:')
         console.log(data)
       })
       .on('Romo.UI.XHR:callError', function(e, romoXHR, data, xhr) {
         statusDOM.appendHTML('<div>-> error</div>')
-        statusDOM.appendHTML(`<code>${data.toString()}</code>`)
+        statusDOM.appendHTML(`<code>${JSON.stringify(data)}</code>`)
         console.log('-> error, data:')
         console.log(data)
       })
@@ -128,15 +129,25 @@
       })
 
     Romo.f('[data-example-5-abort]').on('click', function(e) {
-      Romo.dom(e.target).trigger('Romo.UI.XHR:triggerAbort')
+      Romo.pushFn(function() {
+        Romo
+          .dom(e.target)
+          .trigger('Romo.UI.XHR:triggerAbort')
+      })
     })
 
     Romo.f('[data-example-6-trigger-button]').on('click', function(e) {
-      Romo.dom(e.target).prev('[data-romo-ui-xhr]').trigger('Romo.UI.XHR:triggerCall')
+      Romo
+        .dom(e.target)
+        .prev('[data-romo-ui-xhr]')
+        .trigger('Romo.UI.XHR:triggerCall', [{ other: "value" }])
     })
 
     Romo.f('[data-example-8-enable-button]').on('click', function(e) {
-      Romo.dom(e.target).prev('[data-romo-ui-xhr]').trigger('Romo.UI.XHR:triggerEnable')
+      Romo
+        .dom(e.target)
+        .prev('[data-romo-ui-xhr]')
+        .trigger('Romo.UI.XHR:triggerEnable')
     })
   })
 </script>

--- a/test/tests_server.rb
+++ b/test/tests_server.rb
@@ -1,5 +1,39 @@
+require "pry"
 require "sinatra/base"
 
 class TestsServer < Sinatra::Base
+  # API - Romo.xhr
+
+  get "/api/xhr/info.json" do
+    { propertyName: "property-value" }.merge(params).to_json
+  end
+
+  # UI - Form tests
+
+  get "/ui/forms/info.json" do
+    params.to_h.to_json
+  end
+
+  post "/ui/forms/resource" do
+    params.to_h.to_json
+  end
+
+  # UI - XHR tests
+
+  get "/ui/xhr/info.json" do
+    { propertyName: "property-value" }.merge(params).to_json
+  end
+
+  get "/ui/xhr/aborted.json" do
+    sleep 1
+    { propertyName: "property-value" }.merge(params).to_json
+  end
+
+  post "/ui/xhr/resource" do
+    params.to_h.to_json
+  end
+
+  # Configuration
+
   run! if app_file == $0
 end


### PR DESCRIPTION
I had never formally tested this type of submission so when I
went to use this component and do these types of submissions in
an app, I noticed this bug. Now that we have formal testing in
place for this type of submission, I can repeat that bug.

This fixes the bug. There were two problems:

* I messed up the `Romo.XMLHttpRequest.Data.formData` getter and
  forgot to `return` the `formData` value. This meant it was
  always returning `undefined` and never sending any form data.
  This only occurred on XHR Posts that attempted to send form data.
* On `Romo.UI.Form.XHRPostSubmission`, I was converting the form
  values to a form data object and passing that as data to the
  underlying `Romo.xhr` call. However, that API expects primitive
  Object data. This switched to passing that instead.

# Other Changes

### switch XHR/Form tests to submit to an internal ruby test server route

This is part of bringing on the new test server and removes the
random dependency on an external GitHub JSON API.

### add XHR POST form test

This formally tests XHR POST form submissions and their handling.
This actually makes a bug in this type of form submission
repeatable.

I also reorganized the forms in the tests html file now that we
have multiple XHR forms.

# Demo

![image9awba](https://user-images.githubusercontent.com/82110/118492047-3c473e00-b6e5-11eb-8edc-bc16541c3e82.jpg)
