### PR TITLE
fix Romo.UI.Form.BaseXHRSubmission error message handling

### DIFF
--- a/lib/ui/form/base_xhr_submission.js
+++ b/lib/ui/form/base_xhr_submission.js
@@ -59,8 +59,8 @@ Romo.define('Romo.UI.Form.BaseXHRSubmission', function() {
     _onError(response, status, xhr) {
       this.doRemoveErrorMessages()
 
-      if (xhr.status === 422 && xhr.responseJSON) {
-        this.doAddErrorMessages(xhr.responseJSON)
+      if (xhr.status === 422 && xhr.responseType === Romo.XMLHttpRequest.JSON) {
+        this.doAddErrorMessages(xhr.response)
       }
 
       this.formDOM.trigger('Romo.UI.Form.Submission:submitError', [response, xhr])

--- a/lib/ui/form/base_xhr_submission.js
+++ b/lib/ui/form/base_xhr_submission.js
@@ -14,7 +14,8 @@ Romo.define('Romo.UI.Form.BaseXHRSubmission', function() {
 
     get responseType() {
       return (
-        this.formDOM.data(`${Romo.UI.Form.attrPrefix}-xhr-response-type`)
+        this.formDOM.data(`${Romo.UI.Form.attrPrefix}-xhr-response-type`) ||
+        Romo.XMLHttpRequest.JSON
       )
     }
 

--- a/test/public/ui/form_tests.html
+++ b/test/public/ui/form_tests.html
@@ -56,6 +56,18 @@
             data-romo-ui-spinner>XHR POST Submit</button>
   </form>
 
+  <form action="/ui/forms/resource-422"
+        method="put"
+        accept-charset="UTF-8"
+        data-xhr-put-json-form
+        data-romo-ui-form
+        data-romo-ui-form-disable-focus-on-init="true">
+    <input type="text" name="value" value="thing / something"
+           placeholder="Enter a value.">
+    <button type="submit"
+            data-romo-ui-spinner>XHR PUT Submit w/ 422 response</button>
+  </form>
+
   <div data-form-status>
   </div>
 </body>

--- a/test/public/ui/form_tests.html
+++ b/test/public/ui/form_tests.html
@@ -37,7 +37,6 @@
         accept-charset="UTF-8"
         data-xhr-get-json-form
         data-romo-ui-form
-        data-romo-ui-form-xhr-response-type="json"
         data-romo-ui-form-disable-focus-on-init="true">
     <input type="text" name="value" value="thing / something"
            placeholder="Enter a value.">
@@ -50,7 +49,6 @@
         accept-charset="UTF-8"
         data-xhr-post-json-form
         data-romo-ui-form
-        data-romo-ui-form-xhr-response-type="json"
         data-romo-ui-form-disable-focus-on-init="true">
     <input type="text" name="value" value="thing / something"
            placeholder="Enter a value.">

--- a/test/tests_server.rb
+++ b/test/tests_server.rb
@@ -18,6 +18,10 @@ class TestsServer < Sinatra::Base
     params.to_h.to_json
   end
 
+  put "/ui/forms/resource-422" do
+    halt 422, { field_name: ["can't be blank"] }.to_json
+  end
+
   # UI - XHR tests
 
   get "/ui/xhr/info.json" do


### PR DESCRIPTION
I didn't read the XHR spec carefully enough. It has
`responseText` and `responseXML` methods, so I guess I kinda
assumed it also had a `responseJSON` method. Well that was wrong.

For JSON responses, the `response` method will contain the JSON
if `responseType === 'json'`. This switches the handler logic to
conform to that spec.

Also, I didn't have a formal test for this so I added one.

# Other Changes

### update Romo.UI.Form.BaseXHRSubmission to default to 'json' response types

This is a more reasonable default than the implicit 'text' default
as XHR submissions have no great way of communicating error
messages back without encoding those error messages as JSON.
I think this is a better position for XHR Romo.UI.Forms to take.

# Demo

![image149pe](https://user-images.githubusercontent.com/82110/118665790-38d0b700-b7b8-11eb-80cb-b5b5eb1908a4.jpg)

