### PR TITLE
fallback to status text error response text when XHR error response is null

### DIFF
--- a/lib/utilities/xml_http_request.js
+++ b/lib/utilities/xml_http_request.js
@@ -199,14 +199,16 @@ Romo.define('Romo.XMLHttpRequest', function() {
     _onError() {
       const response =
         this.isNonTextResponseType ? this.xhr.response : this.xhr.responseText
+      const statusText = `${this.xhr.status} ${this.xhr.statusText}`
 
       if (!this.mutedErrorStatusCodes.includes(this.xhr.status)) {
         if (this.isBinaryResponseType) {
-          this.errorResponseText = `${this.xhr.status} ${this.xhr.statusText}`
+          this.errorResponseText = statusText
         } else if (this.responseType === this.class.JSON) {
-          this.errorResponseText = JSON.stringify(response)
+          this.errorResponseText =
+            response ? JSON.stringify(response) : statusText
         } else {
-          this.errorResponseText = response.toString()
+          this.errorResponseText = response ? response.toString() : statusText
         }
       }
 

--- a/test/public/system_tests.html
+++ b/test/public/system_tests.html
@@ -1163,6 +1163,36 @@
           })
           .doAbort()
       })
+
+      tests.test('Given an erroring call', function(test) {
+        // expect an onSuccess handler to pass the test, fail if it isn't invoked
+        test.fail()
+
+        Romo
+          .xhr({
+            url: '/api/xhr/error.json?some=value',
+            data: {
+              other: 'value'
+            },
+            responseType: Romo.XMLHttpRequest.JSON,
+            onSuccess:
+              Romo.bind(function(data, status, xhr) {
+                test.fail('xhr success')
+              }, this),
+            onError:
+              Romo.bind(function(statusMsg, status, xhr) {
+                test.pass()
+              }, this),
+            onAbort:
+              Romo.bind(function(statusMsg, status, xhr) {
+                test.fail('xhr abort')
+              }, this),
+            onTimeout:
+              Romo.bind(function(statusMsg, status, xhr) {
+                test.fail('xhr timeout')
+              }, this),
+          })
+      })
     })
 
     tests.group('API: <code>Romo.url</code>', function() {

--- a/test/tests_server.rb
+++ b/test/tests_server.rb
@@ -8,6 +8,10 @@ class TestsServer < Sinatra::Base
     { propertyName: "property-value" }.merge(params).to_json
   end
 
+  get "/api/xhr/error.json" do
+    raise "error"
+  end
+
   # UI - Form tests
 
   get "/ui/forms/info.json" do


### PR DESCRIPTION
This ensures we always return at least some form of error response
text when there is an XHR error. `null` isn't helpful at all.

This has mostly come up when using JSON response types and getting
a 500 on the server. In this case the alert will now say
"500 Internal Server Error" instead of "null" in the alert debug
message.

# Demo

![imaged8mqp](https://user-images.githubusercontent.com/82110/120078162-b677ab00-c073-11eb-9175-7f2dd9381b8d.jpg)

