### PR TITLE
rework show XHR JSON alerts

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -300,13 +300,9 @@ Romo.config.xhr.showErrorAlertFn =
     console.error(message)
   }
 
-Romo.config.xhr.showJSONBannerAlertFn =
+Romo.config.xhr.showJSONAlertsFn =
   function(xhrResponseJSON) {
     Romo.showBannerAlert(xhrResponseJSON.bannerAlert)
-  }
-
-Romo.config.xhr.showJSONToastAlertsFn =
-  function(xhrResponseJSON) {
     Romo.showToastAlert(xhrResponseJSON.toastAlert)
     Romo.array(xhrResponseJSON.toastAlerts).forEach(function(toastAlert) {
       Romo.showToastAlert(toastAlert)

--- a/lib/utilities/xml_http_request.js
+++ b/lib/utilities/xml_http_request.js
@@ -180,8 +180,7 @@ Romo.define('Romo.XMLHttpRequest', function() {
     // private
 
     _onLoad() {
-      this._showJSONBannerAlert()
-      this._showJSONToastAlerts()
+      this._showJSONAlerts()
 
       if (Romo.config.xhr.isSuccessStatusCode(this.xhr.status)) {
         if (this.onSuccess) {
@@ -257,23 +256,13 @@ Romo.define('Romo.XMLHttpRequest', function() {
       }
     }
 
-    _showJSONBannerAlert() {
+    _showJSONAlerts() {
       if (
         this._getDomain(window.location) === this._getDomain(this.url) &&
         this.xhr.responseType === this.class.JSON &&
         this.xhr.response
       ) {
-        Romo.config.xhr.showJSONBannerAlertFn(this.xhr.response)
-      }
-    }
-
-    _showJSONToastAlerts() {
-      if (
-        this._getDomain(window.location) === this._getDomain(this.url) &&
-        this.xhr.responseType === this.class.JSON &&
-        this.xhr.response
-      ) {
-        Romo.config.xhr.showJSONToastAlertsFn(this.xhr.response)
+        Romo.config.xhr.showJSONAlertsFn(this.xhr.response)
       }
     }
 


### PR DESCRIPTION
This removes the separate banner/toast alert handling and handles
them instead with a single `Romo.config.xhr.showJSONAlertsFn`
function. The previous split up was arbitrary anyway and this
configuration is easier to extend and add additional ad-hoc alerts
to.
